### PR TITLE
feat: self-custodial (Spark) receive via Lightning address

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Unit tests (Vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Local-only working plan (not for publication)
+button_spark_plan.md
+
+# Node / test tooling (added with the Vitest test harness)
+node_modules/
+coverage/
+
+# Editor / OS noise
+.DS_Store
+*.log

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A lightweight, embeddable Bitcoin Lightning donation widget that integrates with
 ## 🚀 Features
 
 - **⚡ Lightning Fast**: Instant Bitcoin Lightning payments via Blink API
+- **🔑 Self-custodial ready**: Works for both custodial Blink accounts and **self-custodial Blink (Spark)** users, addressed by their Blink Lightning address — no extra configuration
 - **💰 Multi-Currency**: Support for 30+ fiat currencies (USD, EUR, GBP, etc.) with automatic conversion
 - **🎨 Customizable**: Light/dark themes and flexible styling
 - **📱 Responsive**: Works perfectly on desktop and mobile devices
@@ -93,6 +94,37 @@ The widget supports 30+ currencies through Blink's exchange rate API:
 **Regional**: ZAR, BRL, MXN, INR, KRW, SGD, THB, PHP  
 **African**: NGN, KES, GHS, UGX, TZS, RWF, ETB  
 **Others**: NOK, SEK, DKK, PLN, CZK, HUF, TRY, ILS, AED, SAR
+
+## 🔑 Self-custodial (Spark) support
+
+The widget works for **both** account types with no change to the embed code:
+
+- **Custodial Blink accounts** use the existing flow (`accountDefaultWallet` →
+  on-behalf-of invoice → real-time WebSocket payment detection).
+- **Self-custodial Blink (Spark) accounts** have no custodial wallet, so the widget
+  automatically falls back to the account's **Blink Lightning address**
+  (`username@blink.sv`): it requests an invoice via LNURL-pay and detects settlement via
+  the LUD-21 `verify` URL.
+
+Funds always land in the user's **current default account** (this is handled server-side
+by the Blink LNURL server — if the user's default is Dollar, the funds arrive in their
+USD account for custodial accounts; self-custodial Spark accounts receive in sats/BTC).
+
+Only `blink.sv` Lightning addresses are supported.
+
+## 🧪 Running the tests
+
+Unit tests (Vitest + jsdom) cover the LNURL-pay / LUD-21 helpers and the self-custodial
+fallback, to prevent regressions:
+
+```bash
+npm install
+npm test          # run once
+npm run test:watch
+```
+
+There is also a manual page, `spark-test.html`, for end-to-end testing against a real
+self-custodial (Spark) username.
 
 ## 📊 Analytics Tracking
 

--- a/js/blink-lnurl.js
+++ b/js/blink-lnurl.js
@@ -1,0 +1,300 @@
+/**
+ * Blink LNURL helpers (self-custodial Spark receive support)
+ *
+ * Pure, side-effect-free helpers for the LNURL-pay (LUD-16) + LUD-21 verify flow
+ * used to receive donations for self-custodial Blink (Spark) Lightning-address
+ * users. Ported from blink-terminal's lib/lnurl.ts.
+ *
+ * Why a separate file: the donation widget (blink-pay-button.js) is shipped as a
+ * single <script> with no build step. These helpers are kept here as a pure
+ * module so they can be unit-tested (Vitest) AND consumed by the widget at
+ * runtime via `window.BlinkLnurl` (the widget falls back to an inline copy if
+ * this file is not loaded, so existing single-file embeds keep working).
+ *
+ * Production / blink.sv ONLY: callers must reject non-Blink domains before using
+ * these helpers (see isBlinkLightningAddress / ALLOWED_BLINK_DOMAINS).
+ *
+ * `fetch` is injected (last argument) so tests can mock it without globals.
+ */
+(function (root, factory) {
+  // UMD: attach to window/globalThis as `BlinkLnurl` for the browser <script>
+  // path, and expose CommonJS/ESM exports for the test runner.
+  const api = factory();
+  // eslint-disable-next-line no-undef
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+  root.BlinkLnurl = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  'use strict';
+
+  // Allowed Blink Lightning-address domains. Anything else is rejected before
+  // any network access (the widget runs in the donor's browser, so the SSRF risk
+  // is lower than Terminal's server path, but we keep the surface tight and
+  // predictable: this widget only serves Blink custodial/Spark receivers).
+  const ALLOWED_BLINK_DOMAINS = ['blink.sv'];
+
+  const defaultFetch =
+    typeof fetch !== 'undefined' ? (...args) => fetch(...args) : null;
+
+  function getFetch(injected) {
+    const f = injected || defaultFetch;
+    if (!f) {
+      throw new Error('No fetch implementation available');
+    }
+    return f;
+  }
+
+  /**
+   * Parse a Lightning address into its LNURL-pay endpoint (LUD-16).
+   * @param {string} address - e.g. "alice@blink.sv"
+   * @returns {{ localpart: string, domain: string, lnurlEndpoint: string }}
+   */
+  function parseLightningAddress(address) {
+    if (!address || typeof address !== 'string') {
+      throw new Error('Invalid Lightning address: address is required');
+    }
+    const parts = address.trim().split('@');
+    if (parts.length !== 2) {
+      throw new Error('Invalid Lightning address format: ' + address);
+    }
+    const localpart = parts[0];
+    const domain = parts[1].toLowerCase();
+    if (!localpart || !domain) {
+      throw new Error('Invalid Lightning address: missing local part or domain');
+    }
+    return {
+      localpart: localpart,
+      domain: domain,
+      lnurlEndpoint: 'https://' + domain + '/.well-known/lnurlp/' + localpart,
+    };
+  }
+
+  /**
+   * Whether an address (or bare domain) is a known Blink Lightning-address domain.
+   * @param {string} address - "alice@blink.sv" or "blink.sv"
+   * @returns {boolean}
+   */
+  function isBlinkLightningAddress(address) {
+    if (!address || typeof address !== 'string') return false;
+    const domain = address.includes('@')
+      ? address.split('@')[1]
+      : address;
+    return ALLOWED_BLINK_DOMAINS.includes((domain || '').trim().toLowerCase());
+  }
+
+  /**
+   * Normalize a user-supplied username/address into a bare blink.sv Lightning
+   * address. Accepts "alice" or "alice@blink.sv"; rejects non-Blink domains.
+   * Strips a leading "lightning:" prefix. Returns the bare address so the LNURL
+   * server's default-account routing applies (a "+usd"/"+btc" suffix would force
+   * a wallet; we intentionally use the bare form so funds land in the user's
+   * current default account).
+   * @param {string} input
+   * @returns {string} e.g. "alice@blink.sv"
+   */
+  function normalizeBlinkLightningAddress(input) {
+    if (!input || typeof input !== 'string') {
+      throw new Error('Username is required');
+    }
+    let value = input.trim();
+    if (value.toLowerCase().startsWith('lightning:')) {
+      value = value.slice('lightning:'.length).trim();
+    }
+    if (value.includes('@')) {
+      const parts = value.split('@');
+      if (parts.length !== 2 || !parts[0] || !parts[1]) {
+        throw new Error('Invalid Lightning address format: ' + input);
+      }
+      const domain = parts[1].toLowerCase();
+      if (!ALLOWED_BLINK_DOMAINS.includes(domain)) {
+        throw new Error(
+          "'" + input + "' is not a Blink address. Only " +
+            ALLOWED_BLINK_DOMAINS[0] + ' addresses are supported.'
+        );
+      }
+      return parts[0] + '@' + domain;
+    }
+    return value + '@' + ALLOWED_BLINK_DOMAINS[0];
+  }
+
+  /**
+   * Fetch LNURL-pay metadata (LUD-06) from an endpoint.
+   * @param {string} lnurlEndpoint
+   * @param {Function} [injectedFetch]
+   * @returns {Promise<{callback:string,minSendable:number,maxSendable:number,metadata?:string,commentAllowed:number}>}
+   */
+  async function fetchLnurlPayMetadata(lnurlEndpoint, injectedFetch) {
+    const doFetch = getFetch(injectedFetch);
+    const response = await doFetch(lnurlEndpoint, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+      throw new Error(
+        'LNURL endpoint returned ' + response.status + ': ' + response.statusText
+      );
+    }
+    const data = await response.json();
+    if (data.tag !== 'payRequest') {
+      throw new Error(
+        "Invalid LNURL tag: expected 'payRequest', got '" + data.tag + "'"
+      );
+    }
+    if (!data.callback) {
+      throw new Error('LNURL response missing callback URL');
+    }
+    if (
+      typeof data.minSendable !== 'number' ||
+      typeof data.maxSendable !== 'number'
+    ) {
+      throw new Error('LNURL response missing min/max sendable amounts');
+    }
+    return {
+      callback: data.callback,
+      minSendable: data.minSendable, // millisatoshis
+      maxSendable: data.maxSendable, // millisatoshis
+      metadata: data.metadata,
+      commentAllowed: data.commentAllowed || 0,
+    };
+  }
+
+  /**
+   * Request an invoice from an LNURL-pay callback.
+   * @param {string} callbackUrl
+   * @param {number} amountMsats
+   * @param {string} [comment]
+   * @param {Function} [injectedFetch]
+   * @returns {Promise<{paymentRequest:string, verify?:string}>}
+   */
+  async function requestInvoiceFromCallback(
+    callbackUrl,
+    amountMsats,
+    comment,
+    injectedFetch
+  ) {
+    const doFetch = getFetch(injectedFetch);
+    const url = new URL(callbackUrl);
+    url.searchParams.set('amount', String(amountMsats));
+    if (comment) {
+      url.searchParams.set('comment', comment);
+    }
+    const response = await doFetch(url.toString(), {
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+      throw new Error(
+        'LNURL callback returned ' + response.status + ': ' + response.statusText
+      );
+    }
+    const data = await response.json();
+    if (data.status === 'ERROR') {
+      throw new Error('LNURL error: ' + (data.reason || 'Unknown error'));
+    }
+    if (!data.pr) {
+      throw new Error('LNURL callback did not return a payment request');
+    }
+    return { paymentRequest: data.pr, verify: data.verify };
+  }
+
+  /**
+   * Complete flow: resolve a Lightning address -> metadata -> invoice.
+   * Spark/Blink always receive in sats; `amountSats` is the donation amount.
+   * @param {string} lightningAddress - e.g. "alice@blink.sv"
+   * @param {number} amountSats
+   * @param {string} [memo]
+   * @param {Function} [injectedFetch]
+   * @returns {Promise<{paymentRequest:string, verifyUrl?:string}>}
+   */
+  async function getInvoiceFromLightningAddress(
+    lightningAddress,
+    amountSats,
+    memo,
+    injectedFetch
+  ) {
+    if (!isBlinkLightningAddress(lightningAddress)) {
+      throw new Error(
+        "'" + lightningAddress + "' is not a Blink address. Only " +
+          ALLOWED_BLINK_DOMAINS[0] + ' addresses are supported.'
+      );
+    }
+    const parsed = parseLightningAddress(lightningAddress);
+    const lnurlData = await fetchLnurlPayMetadata(
+      parsed.lnurlEndpoint,
+      injectedFetch
+    );
+
+    const amountMsats = Math.round(amountSats) * 1000;
+    if (amountMsats < lnurlData.minSendable) {
+      throw new Error(
+        'Amount ' + amountSats + ' sats is below minimum ' +
+          Math.ceil(lnurlData.minSendable / 1000) + ' sats'
+      );
+    }
+    if (amountMsats > lnurlData.maxSendable) {
+      throw new Error(
+        'Amount ' + amountSats + ' sats exceeds maximum ' +
+          Math.floor(lnurlData.maxSendable / 1000) + ' sats'
+      );
+    }
+
+    let comment = memo || '';
+    if (lnurlData.commentAllowed > 0 && comment.length > lnurlData.commentAllowed) {
+      comment = comment.substring(0, lnurlData.commentAllowed);
+    } else if (lnurlData.commentAllowed === 0) {
+      comment = '';
+    }
+
+    const invoice = await requestInvoiceFromCallback(
+      lnurlData.callback,
+      amountMsats,
+      comment,
+      injectedFetch
+    );
+    return {
+      paymentRequest: invoice.paymentRequest,
+      verifyUrl: invoice.verify,
+    };
+  }
+
+  /**
+   * Poll a LUD-21 verify URL to check whether an invoice has been paid.
+   *
+   * Self-custodial (Spark) note: the verify endpoint is populated by the Spark
+   * SSP webhook server-side (no synchronous status pull), so `settled` only
+   * flips to true once that webhook lands. Polling tolerates the lag.
+   * @param {string} verifyUrl
+   * @param {Function} [injectedFetch]
+   * @returns {Promise<{settled:boolean, preimage?:string, pr?:string}>}
+   */
+  async function verifyLnurlPayment(verifyUrl, injectedFetch) {
+    const doFetch = getFetch(injectedFetch);
+    const response = await doFetch(verifyUrl, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+      throw new Error(
+        'LNURL verify returned ' + response.status + ': ' + response.statusText
+      );
+    }
+    const data = await response.json();
+    if (data.status === 'ERROR') {
+      throw new Error('LNURL verify error: ' + (data.reason || 'Unknown error'));
+    }
+    return {
+      settled: data.settled === true,
+      preimage: data.preimage == null ? undefined : data.preimage,
+      pr: data.pr,
+    };
+  }
+
+  return {
+    ALLOWED_BLINK_DOMAINS: ALLOWED_BLINK_DOMAINS,
+    parseLightningAddress: parseLightningAddress,
+    isBlinkLightningAddress: isBlinkLightningAddress,
+    normalizeBlinkLightningAddress: normalizeBlinkLightningAddress,
+    fetchLnurlPayMetadata: fetchLnurlPayMetadata,
+    requestInvoiceFromCallback: requestInvoiceFromCallback,
+    getInvoiceFromLightningAddress: getInvoiceFromLightningAddress,
+    verifyLnurlPayment: verifyLnurlPayment,
+  };
+});

--- a/js/blink-pay-button.js
+++ b/js/blink-pay-button.js
@@ -1,7 +1,8 @@
 /**
  * Blink Pay Button Widget
  * A simple widget for accepting Bitcoin Lightning donations via Blink wallet
- * Version: 1.2.3 - Reduced button font size by 2pts for better appearance
+ * Version: 1.3.0 - Self-custodial (Spark) receive via Lightning address (LNURL-pay
+ *                  custodial-first fallback + LUD-21 verify). Custodial flow unchanged.
  */
 (function() {
     // Translation objects for multi-language support
@@ -1401,14 +1402,23 @@
                 try {
                     this.log(`Processing donation: ${amount} ${this.selectedCurrency}`);
                     
-                    // Step 1: Get wallet information
+                    // Step 1: Get wallet information (custodial-first).
                     this.log('About to call getAccountDefaultWallet');
                     if (typeof this.getAccountDefaultWallet !== 'function') {
                         throw new Error('getAccountDefaultWallet is not a function - this context may be lost');
                     }
                     const walletInfo = await this.getAccountDefaultWallet(this.username);
+
+                    // SELF-CUSTODIAL (Spark) FALLBACK:
+                    // A self-custodial Blink (Spark) user has no custodial wallet, so
+                    // accountDefaultWallet returns no id. Fall back to the Lightning
+                    // address (LNURL-pay) path: invoice directly on `username@blink.sv`
+                    // and detect settlement via LUD-21 verify. Funds land in the user's
+                    // current default account (handled server-side by the LNURL server).
                     if (!walletInfo || !walletInfo.id) {
-                        throw new Error('Could not retrieve wallet information for this username');
+                        this.log('No custodial wallet; trying self-custodial (Spark) LN-address path');
+                        await this.handleSelfCustodialDonate(amount);
+                        return;
                     }
                     this.log(`Retrieved wallet info:`, walletInfo);
                     
@@ -1460,6 +1470,157 @@
             }
         },
         
+        // Resolve the BlinkLnurl helper module. When the widget is embedded as a
+        // single <script> (the common case), js/blink-lnurl.js is not separately
+        // loaded, so we fall back to an inline, behaviour-identical copy of the
+        // few helpers we need. The canonical, unit-tested implementation lives in
+        // js/blink-lnurl.js (see tests/).
+        getLnurl: function() {
+            if (typeof window !== 'undefined' && window.BlinkLnurl) {
+                return window.BlinkLnurl;
+            }
+            if (this._inlineLnurl) return this._inlineLnurl;
+
+            const ALLOWED_BLINK_DOMAINS = ['blink.sv'];
+            const self = this;
+            const inline = {
+                ALLOWED_BLINK_DOMAINS: ALLOWED_BLINK_DOMAINS,
+                isBlinkLightningAddress: function(address) {
+                    if (!address || typeof address !== 'string') return false;
+                    const domain = address.includes('@') ? address.split('@')[1] : address;
+                    return ALLOWED_BLINK_DOMAINS.includes((domain || '').trim().toLowerCase());
+                },
+                normalizeBlinkLightningAddress: function(input) {
+                    if (!input || typeof input !== 'string') throw new Error('Username is required');
+                    let value = input.trim();
+                    if (value.toLowerCase().startsWith('lightning:')) {
+                        value = value.slice('lightning:'.length).trim();
+                    }
+                    if (value.includes('@')) {
+                        const parts = value.split('@');
+                        if (parts.length !== 2 || !parts[0] || !parts[1]) {
+                            throw new Error('Invalid Lightning address format: ' + input);
+                        }
+                        const domain = parts[1].toLowerCase();
+                        if (!ALLOWED_BLINK_DOMAINS.includes(domain)) {
+                            throw new Error("'" + input + "' is not a Blink address. Only " + ALLOWED_BLINK_DOMAINS[0] + ' addresses are supported.');
+                        }
+                        return parts[0] + '@' + domain;
+                    }
+                    return value + '@' + ALLOWED_BLINK_DOMAINS[0];
+                },
+                getInvoiceFromLightningAddress: async function(lightningAddress, amountSats, memo) {
+                    if (!inline.isBlinkLightningAddress(lightningAddress)) {
+                        throw new Error("'" + lightningAddress + "' is not a Blink address.");
+                    }
+                    const parts = lightningAddress.split('@');
+                    const lnurlEndpoint = 'https://' + parts[1].toLowerCase() + '/.well-known/lnurlp/' + parts[0];
+                    const metaResp = await fetch(lnurlEndpoint, { headers: { Accept: 'application/json' } });
+                    if (!metaResp.ok) throw new Error('LNURL endpoint returned ' + metaResp.status);
+                    const meta = await metaResp.json();
+                    if (meta.tag !== 'payRequest' || !meta.callback) throw new Error('Invalid LNURL pay response');
+                    if (typeof meta.minSendable !== 'number' || typeof meta.maxSendable !== 'number') {
+                        throw new Error('LNURL response missing min/max sendable amounts');
+                    }
+                    const amountMsats = Math.round(amountSats) * 1000;
+                    if (amountMsats < meta.minSendable) {
+                        throw new Error('Amount ' + amountSats + ' sats is below minimum ' + Math.ceil(meta.minSendable / 1000) + ' sats');
+                    }
+                    if (amountMsats > meta.maxSendable) {
+                        throw new Error('Amount ' + amountSats + ' sats exceeds maximum ' + Math.floor(meta.maxSendable / 1000) + ' sats');
+                    }
+                    let comment = memo || '';
+                    const commentAllowed = meta.commentAllowed || 0;
+                    if (commentAllowed > 0 && comment.length > commentAllowed) comment = comment.substring(0, commentAllowed);
+                    else if (commentAllowed === 0) comment = '';
+                    const url = new URL(meta.callback);
+                    url.searchParams.set('amount', String(amountMsats));
+                    if (comment) url.searchParams.set('comment', comment);
+                    const cbResp = await fetch(url.toString(), { headers: { Accept: 'application/json' } });
+                    if (!cbResp.ok) throw new Error('LNURL callback returned ' + cbResp.status);
+                    const cb = await cbResp.json();
+                    if (cb.status === 'ERROR') throw new Error('LNURL error: ' + (cb.reason || 'Unknown error'));
+                    if (!cb.pr) throw new Error('LNURL callback did not return a payment request');
+                    return { paymentRequest: cb.pr, verifyUrl: cb.verify };
+                },
+                verifyLnurlPayment: async function(verifyUrl) {
+                    const resp = await fetch(verifyUrl, { headers: { Accept: 'application/json' } });
+                    if (!resp.ok) throw new Error('LNURL verify returned ' + resp.status);
+                    const data = await resp.json();
+                    if (data.status === 'ERROR') throw new Error('LNURL verify error: ' + (data.reason || 'Unknown error'));
+                    return { settled: data.settled === true, preimage: data.preimage == null ? undefined : data.preimage, pr: data.pr };
+                },
+            };
+            void self;
+            this._inlineLnurl = inline;
+            return inline;
+        },
+
+        // Self-custodial (Spark) donation path: invoice on the merchant's Blink
+        // Lightning address via LNURL-pay, then detect settlement via LUD-21
+        // verify polling. Always denominated in sats (Spark is BTC-only).
+        handleSelfCustodialDonate: async function(amount) {
+            const lnurl = this.getLnurl();
+
+            // Build the bare blink.sv Lightning address (rejects non-Blink domains).
+            // Bare address => funds land in the user's current default account
+            // (server-side default-wallet routing).
+            const lightningAddress = lnurl.normalizeBlinkLightningAddress(this.username);
+
+            // Spark/Blink receive in sats; convert the selected display currency.
+            const satsAmount = this.convertToSatoshis(amount, this.selectedCurrency);
+            this.log('Self-custodial: requesting LN-address invoice', { lightningAddress, satsAmount });
+
+            const memo = `${this.username} donation button`;
+            const invoice = await lnurl.getInvoiceFromLightningAddress(
+                lightningAddress,
+                satsAmount,
+                memo
+            );
+            if (!invoice || !invoice.paymentRequest) {
+                throw new Error('Could not create invoice');
+            }
+            this.log('Self-custodial invoice created (direct, no escrow)', {
+                paymentRequest: invoice.paymentRequest.substring(0, 30) + '...',
+                hasVerify: Boolean(invoice.verifyUrl),
+            });
+
+            // LN-address invoices default to a 15-minute expiry on the Blink LNURL server.
+            const expiryMinutes = 15;
+            this.displayInvoice(invoice.paymentRequest, expiryMinutes);
+
+            if (invoice.verifyUrl) {
+                this.pollVerifyStatus(invoice.verifyUrl);
+            } else {
+                // No verify URL advertised: fall back to the Blink GraphQL poll,
+                // which still works for invoices the Blink backend can observe.
+                this.log('No LUD-21 verify URL; falling back to GraphQL payment polling');
+                this.pollPaymentStatus(invoice.paymentRequest);
+            }
+        },
+
+        // Poll a LUD-21 verify URL until the invoice is settled (Spark path).
+        // Bounded in practice by the invoice expiry countdown shown to the donor.
+        pollVerifyStatus: function(verifyUrl) {
+            const lnurl = this.getLnurl();
+            this.log('Starting LUD-21 verify polling');
+            const check = async () => {
+                try {
+                    const result = await lnurl.verifyLnurlPayment(verifyUrl);
+                    if (result && result.settled === true) {
+                        this.log('Payment confirmed via LUD-21 verify! 🎉');
+                        this.handlePaymentSuccess();
+                        return; // stop polling
+                    }
+                    setTimeout(check, 2000);
+                } catch (error) {
+                    this.log(`Error polling verify status: ${error.message}`, error);
+                    setTimeout(check, 5000); // back off on error
+                }
+            };
+            check();
+        },
+
         // Get the default wallet information for a username
         getAccountDefaultWallet: async function(username) {
             const query = `
@@ -1491,19 +1652,27 @@
                 const data = await response.json();
                 this.log(`API response for accountDefaultWallet`, data);
                 
-                if (data.errors) {
-                    throw new Error(data.errors[0].message || 'Error fetching wallet information');
+                // A self-custodial (Spark) username has no custodial wallet, so the
+                // API returns an error (or a null wallet) here. Treat that as "no
+                // custodial wallet" and return { id: null } so the caller falls back
+                // to the self-custodial Lightning-address (LNURL-pay) path instead of
+                // failing the donation.
+                if (data.errors || !data.data || !data.data.accountDefaultWallet?.id) {
+                    this.log('No custodial default wallet for username (likely self-custodial/Spark)');
+                    return { id: null, currency: null };
                 }
                 
                 return {
-                    id: data.data.accountDefaultWallet?.id,
-                    currency: data.data.accountDefaultWallet?.currency
+                    id: data.data.accountDefaultWallet.id,
+                    currency: data.data.accountDefaultWallet.currency
                 };
                 
             } catch (error) {
+                // Network/transport error. Return no-wallet so the self-custodial
+                // fallback can still attempt the LNURL path.
                 this.log(`API error for accountDefaultWallet: ${error.message}`, error);
                 console.error('Error getting wallet information:', error);
-                throw error;
+                return { id: null, currency: null };
             }
         },
         
@@ -2414,7 +2583,7 @@
             }
             
             // Add widget version for tracking
-            params.append('widget_version', '1.2.3');
+            params.append('widget_version', '1.3.0');
             
             return `${baseUrl}?${params.toString()}`;
         }

--- a/js/generator.js
+++ b/js/generator.js
@@ -256,7 +256,16 @@ document.addEventListener('DOMContentLoaded', function() {
             
             // usernameAvailable: true means username does NOT exist
             // usernameAvailable: false means username DOES exist
-            return !data.data.usernameAvailable;
+            if (!data.data.usernameAvailable) {
+                return true; // exists as a custodial Blink username
+            }
+
+            // Self-custodial (Spark) fallback: a Spark user has a registered Blink
+            // Lightning address but may report as "available" via usernameAvailable.
+            // Probe the LNURL-pay endpoint; a valid payRequest means the address
+            // exists and is payable, so generation should proceed.
+            const existsViaLnurl = await checkBlinkLnAddressExists(username);
+            return existsViaLnurl;
             
         } catch (error) {
             console.error('Error checking username:', error);
@@ -265,6 +274,24 @@ document.addEventListener('DOMContentLoaded', function() {
                 throw error;
             }
             // On other errors, allow generation to proceed (assume username exists)
+            return true;
+        }
+    }
+
+    // Self-custodial (Spark) existence probe via LNURL-pay (LUD-16).
+    // Returns true if `username@blink.sv` resolves to a valid payRequest.
+    async function checkBlinkLnAddressExists(username) {
+        try {
+            const endpoint = `https://blink.sv/.well-known/lnurlp/${encodeURIComponent(username)}`;
+            const response = await fetch(endpoint, { headers: { Accept: 'application/json' } });
+            if (!response.ok) {
+                return false;
+            }
+            const data = await response.json();
+            return data && data.tag === 'payRequest' && Boolean(data.callback);
+        } catch (lnurlError) {
+            console.error('Error probing Blink Lightning address:', lnurlError);
+            // Network/other error: don't block generation.
             return true;
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1964 @@
+{
+  "name": "blink-donation-button",
+  "version": "1.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "blink-donation-button",
+      "version": "1.3.0",
+      "devDependencies": {
+        "jsdom": "^25.0.1",
+        "vitest": "^4.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.137.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.3",
+        "@rolldown/binding-darwin-arm64": "1.1.3",
+        "@rolldown/binding-darwin-x64": "1.1.3",
+        "@rolldown/binding-freebsd-x64": "1.1.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+        "@rolldown/binding-linux-arm64-musl": "1.1.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-musl": "1.1.3",
+        "@rolldown/binding-openharmony-arm64": "1.1.3",
+        "@rolldown/binding-wasm32-wasi": "1.1.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+        "@rolldown/binding-win32-x64-msvc": "1.1.3"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "~1.1.2",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "blink-donation-button",
+  "version": "1.3.0",
+  "description": "Blink Pay Button donation widget — tests for custodial + self-custodial (Spark) receive.",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "jsdom": "^25.0.1",
+    "vitest": "^4.0.0"
+  }
+}

--- a/spark-test.html
+++ b/spark-test.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Blink Pay Button — Self-custodial (Spark) test</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            max-width: 760px;
+            margin: 40px auto;
+            padding: 0 20px;
+            line-height: 1.5;
+        }
+        .test-container {
+            margin: 24px 0;
+            padding: 20px;
+            border: 1px solid #e0e0e0;
+            border-radius: 10px;
+        }
+        h1 { font-size: 22px; }
+        h3 { margin-top: 0; }
+        .note {
+            background: #fff8e1;
+            border: 1px solid #ffe0a3;
+            border-radius: 8px;
+            padding: 12px 14px;
+            font-size: 14px;
+        }
+        code { background: #f1f1f1; padding: 1px 5px; border-radius: 4px; }
+        .log {
+            margin-top: 10px;
+            font-size: 12px;
+            font-family: monospace;
+            white-space: pre-wrap;
+            color: #555;
+            max-height: 220px;
+            overflow: auto;
+            background: #fafafa;
+            border: 1px solid #eee;
+            border-radius: 6px;
+            padding: 8px;
+        }
+        label { font-size: 13px; }
+        input { padding: 6px 8px; font-size: 14px; width: 280px; }
+    </style>
+</head>
+<body>
+    <h1>Self-custodial (Spark) donation button — manual test</h1>
+
+    <div class="note">
+        This page exercises the <strong>self-custodial (Spark) receive path</strong>.
+        Enter a Blink username whose account is <strong>self-custodial (Spark)</strong>
+        (e.g. <code>yasar</code>). The widget will: try the custodial
+        <code>accountDefaultWallet</code> first, find no custodial wallet, then fall back
+        to the Lightning-address (LNURL-pay) flow and detect settlement via the LUD-21
+        <code>verify</code> URL. A custodial username (e.g. <code>pretyflaco</code>) should
+        still use the unchanged custodial flow.
+    </div>
+
+    <div class="test-container">
+        <h3>Configure</h3>
+        <label>Blink username:
+            <input id="username-input" type="text" value="yasar" />
+        </label>
+        <button id="reload-btn" type="button">Load widget</button>
+        <div id="blink-pay-button-container" style="margin-top:16px;"></div>
+        <div class="log" id="log">Logs will appear here…</div>
+    </div>
+
+    <script src="js/blink-pay-button.js"></script>
+    <script>
+        const logEl = document.getElementById('log');
+        const origLog = console.log;
+        console.log = function (...args) {
+            origLog.apply(console, args);
+            try {
+                logEl.textContent += '\n' + args.map(a =>
+                    typeof a === 'object' ? JSON.stringify(a) : String(a)
+                ).join(' ');
+            } catch (e) { /* ignore */ }
+        };
+
+        function loadWidget() {
+            const username = document.getElementById('username-input').value.trim();
+            document.getElementById('blink-pay-button-container').innerHTML = '';
+            logEl.textContent = 'Loading widget for: ' + username;
+            BlinkPayButton.init({
+                username: username,
+                containerId: 'blink-pay-button-container',
+                buttonText: 'Donate Bitcoin',
+                themeMode: 'light',
+                defaultAmount: 1000,
+                debug: true,
+                supportedCurrencies: [
+                    { code: 'sats', name: 'sats', isCrypto: true },
+                    { code: 'USD', name: 'USD', isCrypto: false },
+                ],
+            });
+        }
+
+        document.getElementById('reload-btn').addEventListener('click', loadWidget);
+        loadWidget();
+    </script>
+</body>
+</html>

--- a/tests/blink-lnurl.spec.js
+++ b/tests/blink-lnurl.spec.js
@@ -1,0 +1,246 @@
+/**
+ * Tests for js/blink-lnurl.js — the canonical, browser-and-test shared LNURL
+ * helpers used for self-custodial (Spark) donation receive.
+ *
+ * The helper file is UMD (attaches to globalThis.BlinkLnurl and sets
+ * module.exports). We load it via createRequire so the CommonJS export path is
+ * exercised exactly as Node/test consumers see it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadUmd } from './load-umd.js';
+
+const BlinkLnurl = loadUmd('../js/blink-lnurl.js');
+
+// Helper to build a fake fetch returning a JSON body with a given ok/status.
+function jsonResponse(body, { ok = true, status = 200, statusText = 'OK' } = {}) {
+  return {
+    ok,
+    status,
+    statusText,
+    json: async () => body,
+  };
+}
+
+describe('blink-lnurl helpers', () => {
+  describe('parseLightningAddress', () => {
+    it('parses a valid blink.sv address into a LUD-16 endpoint', () => {
+      const r = BlinkLnurl.parseLightningAddress('alice@blink.sv');
+      expect(r.localpart).toBe('alice');
+      expect(r.domain).toBe('blink.sv');
+      expect(r.lnurlEndpoint).toBe('https://blink.sv/.well-known/lnurlp/alice');
+    });
+
+    it('throws on malformed addresses', () => {
+      expect(() => BlinkLnurl.parseLightningAddress('no-at-sign')).toThrow();
+      expect(() => BlinkLnurl.parseLightningAddress('a@b@c')).toThrow();
+      expect(() => BlinkLnurl.parseLightningAddress('')).toThrow();
+    });
+  });
+
+  describe('isBlinkLightningAddress', () => {
+    it('accepts blink.sv (address or bare domain), case-insensitive', () => {
+      expect(BlinkLnurl.isBlinkLightningAddress('alice@blink.sv')).toBe(true);
+      expect(BlinkLnurl.isBlinkLightningAddress('alice@BLINK.SV')).toBe(true);
+      expect(BlinkLnurl.isBlinkLightningAddress('blink.sv')).toBe(true);
+    });
+
+    it('rejects non-Blink domains', () => {
+      expect(BlinkLnurl.isBlinkLightningAddress('alice@evil.com')).toBe(false);
+      expect(BlinkLnurl.isBlinkLightningAddress('evil.com')).toBe(false);
+      expect(BlinkLnurl.isBlinkLightningAddress('')).toBe(false);
+    });
+  });
+
+  describe('normalizeBlinkLightningAddress', () => {
+    it('turns a bare username into username@blink.sv', () => {
+      expect(BlinkLnurl.normalizeBlinkLightningAddress('alice')).toBe('alice@blink.sv');
+    });
+
+    it('preserves an explicit blink.sv address (lowercased domain)', () => {
+      expect(BlinkLnurl.normalizeBlinkLightningAddress('alice@BLINK.SV')).toBe('alice@blink.sv');
+    });
+
+    it('strips a lightning: prefix', () => {
+      expect(BlinkLnurl.normalizeBlinkLightningAddress('lightning:alice')).toBe('alice@blink.sv');
+    });
+
+    it('rejects an explicit non-Blink domain', () => {
+      expect(() => BlinkLnurl.normalizeBlinkLightningAddress('alice@evil.com')).toThrow(/not a Blink address/i);
+    });
+
+    it('rejects empty input', () => {
+      expect(() => BlinkLnurl.normalizeBlinkLightningAddress('')).toThrow();
+    });
+  });
+
+  describe('fetchLnurlPayMetadata', () => {
+    it('returns parsed metadata for a valid payRequest', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({
+          tag: 'payRequest',
+          callback: 'https://blink.sv/lnurlp/alice/invoice',
+          minSendable: 1000,
+          maxSendable: 100000000,
+          metadata: '[["text/plain","pay alice"]]',
+          commentAllowed: 120,
+        })
+      );
+      const meta = await BlinkLnurl.fetchLnurlPayMetadata(
+        'https://blink.sv/.well-known/lnurlp/alice',
+        fetchMock
+      );
+      expect(meta.callback).toBe('https://blink.sv/lnurlp/alice/invoice');
+      expect(meta.minSendable).toBe(1000);
+      expect(meta.maxSendable).toBe(100000000);
+      expect(meta.commentAllowed).toBe(120);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws on a non-payRequest tag', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ tag: 'withdrawRequest' }));
+      await expect(
+        BlinkLnurl.fetchLnurlPayMetadata('https://blink.sv/x', fetchMock)
+      ).rejects.toThrow(/payRequest/);
+    });
+
+    it('throws on a non-ok HTTP response', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({}, { ok: false, status: 404, statusText: 'Not Found' })
+      );
+      await expect(
+        BlinkLnurl.fetchLnurlPayMetadata('https://blink.sv/x', fetchMock)
+      ).rejects.toThrow(/404/);
+    });
+  });
+
+  describe('requestInvoiceFromCallback', () => {
+    it('appends amount + comment and returns pr/verify', async () => {
+      let calledUrl = '';
+      const fetchMock = vi.fn().mockImplementation((url) => {
+        calledUrl = url;
+        return Promise.resolve(
+          jsonResponse({ pr: 'lnbc1invoice', verify: 'https://blink.sv/verify/h' })
+        );
+      });
+      const result = await BlinkLnurl.requestInvoiceFromCallback(
+        'https://blink.sv/lnurlp/alice/invoice',
+        5000000,
+        'hello',
+        fetchMock
+      );
+      expect(result.paymentRequest).toBe('lnbc1invoice');
+      expect(result.verify).toBe('https://blink.sv/verify/h');
+      expect(calledUrl).toContain('amount=5000000');
+      expect(calledUrl).toContain('comment=hello');
+    });
+
+    it('throws on an LNURL ERROR status', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({ status: 'ERROR', reason: 'amount out of range' })
+      );
+      await expect(
+        BlinkLnurl.requestInvoiceFromCallback('https://blink.sv/cb', 1000, '', fetchMock)
+      ).rejects.toThrow(/amount out of range/);
+    });
+
+    it('throws when no pr is returned', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ routes: [] }));
+      await expect(
+        BlinkLnurl.requestInvoiceFromCallback('https://blink.sv/cb', 1000, '', fetchMock)
+      ).rejects.toThrow(/payment request/);
+    });
+  });
+
+  describe('getInvoiceFromLightningAddress', () => {
+    function metaFetch(meta) {
+      // First call: metadata. Second call: callback invoice.
+      return vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse(meta))
+        .mockResolvedValueOnce(
+          jsonResponse({ pr: 'lnbc1sparkinvoice', verify: 'https://blink.sv/verify/abc' })
+        );
+    }
+
+    const goodMeta = {
+      tag: 'payRequest',
+      callback: 'https://blink.sv/lnurlp/yasar/invoice',
+      minSendable: 1000, // 1 sat
+      maxSendable: 100000000, // 100k sat
+      commentAllowed: 120,
+    };
+
+    it('resolves a blink.sv address end-to-end and returns paymentRequest + verifyUrl', async () => {
+      const fetchMock = metaFetch(goodMeta);
+      const result = await BlinkLnurl.getInvoiceFromLightningAddress(
+        'yasar@blink.sv',
+        5000,
+        'yasar donation button',
+        fetchMock
+      );
+      expect(result.paymentRequest).toBe('lnbc1sparkinvoice');
+      expect(result.verifyUrl).toBe('https://blink.sv/verify/abc');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects a non-Blink domain WITHOUT any network call (SSRF-tightening)', async () => {
+      const fetchMock = vi.fn();
+      await expect(
+        BlinkLnurl.getInvoiceFromLightningAddress('alice@evil.com', 5000, '', fetchMock)
+      ).rejects.toThrow(/not a Blink address/i);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects an amount below minSendable', async () => {
+      const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(goodMeta));
+      await expect(
+        BlinkLnurl.getInvoiceFromLightningAddress('yasar@blink.sv', 0, '', fetchMock)
+      ).rejects.toThrow(/below minimum/i);
+    });
+
+    it('rejects an amount above maxSendable', async () => {
+      const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(goodMeta));
+      await expect(
+        BlinkLnurl.getInvoiceFromLightningAddress('yasar@blink.sv', 200000, '', fetchMock)
+      ).rejects.toThrow(/exceeds maximum/i);
+    });
+  });
+
+  describe('verifyLnurlPayment', () => {
+    it('reports settled=true when the verify endpoint says so', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({ status: 'OK', settled: true, preimage: 'deadbeef', pr: 'lnbc1' })
+      );
+      const r = await BlinkLnurl.verifyLnurlPayment('https://blink.sv/verify/h', fetchMock);
+      expect(r.settled).toBe(true);
+      expect(r.preimage).toBe('deadbeef');
+    });
+
+    it('reports settled=false while unpaid', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({ status: 'OK', settled: false, preimage: null, pr: 'lnbc1' })
+      );
+      const r = await BlinkLnurl.verifyLnurlPayment('https://blink.sv/verify/h', fetchMock);
+      expect(r.settled).toBe(false);
+      expect(r.preimage).toBeUndefined();
+    });
+
+    it('throws on an ERROR status', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({ status: 'ERROR', reason: 'not found' })
+      );
+      await expect(
+        BlinkLnurl.verifyLnurlPayment('https://blink.sv/verify/h', fetchMock)
+      ).rejects.toThrow(/not found/);
+    });
+
+    it('throws on a non-ok HTTP response', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({}, { ok: false, status: 502, statusText: 'Bad Gateway' })
+      );
+      await expect(
+        BlinkLnurl.verifyLnurlPayment('https://blink.sv/verify/h', fetchMock)
+      ).rejects.toThrow(/502/);
+    });
+  });
+});

--- a/tests/load-umd.js
+++ b/tests/load-umd.js
@@ -1,0 +1,23 @@
+/**
+ * Test helper: load a UMD file (like js/blink-lnurl.js) and return its exports.
+ *
+ * The widget ships its helpers as a single-file UMD (browser <script> +
+ * module.exports), and package.json sets "type": "module", which makes a bare
+ * `require('../js/foo.js')` treat the file as ESM (returning an empty namespace).
+ * To exercise the exact CommonJS export path the file declares, we evaluate it
+ * in a minimal module sandbox.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+export function loadUmd(relativePath) {
+  const src = readFileSync(resolve(here, relativePath), 'utf8');
+  const moduleObj = { exports: {} };
+  // eslint-disable-next-line no-new-func
+  const run = new Function('module', 'exports', 'globalThis', src);
+  run(moduleObj, moduleObj.exports, globalThis);
+  return moduleObj.exports;
+}

--- a/tests/widget-spark.spec.js
+++ b/tests/widget-spark.spec.js
@@ -1,0 +1,177 @@
+/**
+ * Contract tests for the widget's self-custodial (Spark) path in
+ * js/blink-pay-button.js.
+ *
+ * The widget ships as a single <script>, so it carries an INLINE copy of the
+ * LNURL helpers (BlinkPayButton.getLnurl()) used when js/blink-lnurl.js is not
+ * separately loaded. These tests:
+ *   1. load the widget into jsdom (it assigns window.BlinkPayButton),
+ *   2. exercise the inline helpers via a stubbed window.fetch, and
+ *   3. assert the inline behaviour matches the canonical js/blink-lnurl.js module
+ *      (so the two cannot silently drift).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { loadUmd } from './load-umd.js';
+
+const Canonical = loadUmd('../js/blink-lnurl.js');
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const widgetSrc = readFileSync(
+  resolve(__dirname, '../js/blink-pay-button.js'),
+  'utf8'
+);
+
+// Load the widget IIFE into the current (jsdom) realm so it assigns
+// window.BlinkPayButton. Runs once; the object is stateless for our purposes.
+function loadWidget() {
+  // eslint-disable-next-line no-new-func
+  const run = new Function(widgetSrc);
+  run();
+  return window.BlinkPayButton;
+}
+
+function jsonResponse(body, { ok = true, status = 200, statusText = 'OK' } = {}) {
+  return { ok, status, statusText, json: async () => body };
+}
+
+let widget;
+
+beforeEach(() => {
+  // Ensure the inline path is used (canonical global not present).
+  delete window.BlinkLnurl;
+  widget = loadWidget();
+  // Fresh inline helper cache per test.
+  widget._inlineLnurl = null;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete window.fetch;
+  delete global.fetch;
+});
+
+describe('widget inline Spark helpers (getLnurl)', () => {
+  it('uses window.BlinkLnurl when present (prefers the canonical module)', () => {
+    window.BlinkLnurl = Canonical;
+    widget._inlineLnurl = null;
+    expect(widget.getLnurl()).toBe(Canonical);
+    delete window.BlinkLnurl;
+  });
+
+  it('inline normalizeBlinkLightningAddress matches the canonical module', () => {
+    const inline = widget.getLnurl();
+    for (const input of ['alice', 'alice@blink.sv', 'lightning:alice', 'bob@BLINK.SV']) {
+      expect(inline.normalizeBlinkLightningAddress(input)).toBe(
+        Canonical.normalizeBlinkLightningAddress(input)
+      );
+    }
+    expect(() => inline.normalizeBlinkLightningAddress('a@evil.com')).toThrow(/not a Blink address/i);
+  });
+
+  it('inline isBlinkLightningAddress matches the canonical module', () => {
+    const inline = widget.getLnurl();
+    for (const a of ['alice@blink.sv', 'alice@evil.com', 'blink.sv', '']) {
+      expect(inline.isBlinkLightningAddress(a)).toBe(Canonical.isBlinkLightningAddress(a));
+    }
+  });
+
+  it('inline getInvoiceFromLightningAddress resolves end-to-end via stubbed fetch', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          tag: 'payRequest',
+          callback: 'https://blink.sv/lnurlp/yasar/invoice',
+          minSendable: 1000,
+          maxSendable: 100000000,
+          commentAllowed: 120,
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ pr: 'lnbc1sparkinvoice', verify: 'https://blink.sv/verify/abc' })
+      );
+    window.fetch = fetchMock;
+    global.fetch = fetchMock;
+
+    const inline = widget.getLnurl();
+    const result = await inline.getInvoiceFromLightningAddress(
+      'yasar@blink.sv',
+      5000,
+      'yasar donation button'
+    );
+    expect(result.paymentRequest).toBe('lnbc1sparkinvoice');
+    expect(result.verifyUrl).toBe('https://blink.sv/verify/abc');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('inline getInvoiceFromLightningAddress rejects a non-Blink domain with no fetch', async () => {
+    const fetchMock = vi.fn();
+    window.fetch = fetchMock;
+    global.fetch = fetchMock;
+    const inline = widget.getLnurl();
+    await expect(
+      inline.getInvoiceFromLightningAddress('alice@evil.com', 5000, '')
+    ).rejects.toThrow(/not a Blink address/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('inline verifyLnurlPayment reports settled state', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ status: 'OK', settled: false }))
+      .mockResolvedValueOnce(jsonResponse({ status: 'OK', settled: true, preimage: 'p' }));
+    window.fetch = fetchMock;
+    global.fetch = fetchMock;
+
+    const inline = widget.getLnurl();
+    expect((await inline.verifyLnurlPayment('https://blink.sv/verify/h')).settled).toBe(false);
+    const paid = await inline.verifyLnurlPayment('https://blink.sv/verify/h');
+    expect(paid.settled).toBe(true);
+    expect(paid.preimage).toBe('p');
+  });
+});
+
+describe('widget getAccountDefaultWallet (custodial probe)', () => {
+  it('returns { id: null } for a self-custodial username (no custodial wallet)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({ data: { accountDefaultWallet: null } })
+    );
+    window.fetch = fetchMock;
+    global.fetch = fetchMock;
+    widget.username = 'yasar';
+    widget.debug = false;
+
+    const info = await widget.getAccountDefaultWallet('yasar');
+    expect(info.id).toBeNull();
+  });
+
+  it('returns the wallet id for a custodial username', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({ data: { accountDefaultWallet: { id: 'wallet-123', currency: 'BTC' } } })
+    );
+    window.fetch = fetchMock;
+    global.fetch = fetchMock;
+    widget.username = 'pretyflaco';
+    widget.debug = false;
+
+    const info = await widget.getAccountDefaultWallet('pretyflaco');
+    expect(info.id).toBe('wallet-123');
+    expect(info.currency).toBe('BTC');
+  });
+
+  it('returns { id: null } (not throw) when the API returns GraphQL errors', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({ errors: [{ message: 'no account' }] })
+    );
+    window.fetch = fetchMock;
+    global.fetch = fetchMock;
+    widget.username = 'ghost';
+    widget.debug = false;
+
+    const info = await widget.getAccountDefaultWallet('ghost');
+    expect(info.id).toBeNull();
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['tests/**/*.spec.js'],
+    globals: false,
+  },
+});


### PR DESCRIPTION
## Summary

Makes the donation-button widget receive for **self-custodial Blink (Spark)**
Lightning-address users, in addition to the custodial accounts it already
supports — with no change to the embed code. When a username has no custodial
wallet, the widget falls back to the account's Blink Lightning address
(`username@blink.sv`) via LNURL-pay and detects settlement via the LUD-21
`verify` URL.

This mirrors the approach already shipped in blink-terminal. The widget is
pure-frontend; this works because the Blink LNURL server sets permissive CORS on
the well-known / callback / verify endpoints, so the donor's browser can run the
whole flow directly.

## What's included

- **`js/blink-lnurl.js`** (new) — UMD module with the LNURL-pay (LUD-16) +
  LUD-21 verify helpers (parse / metadata / invoice / verify; `blink.sv`-only;
  `fetch`-injectable), ported from blink-terminal's `lib/lnurl.ts`. Loaded via
  `window.BlinkLnurl`.
- **`js/blink-pay-button.js`** — `handleDonate` now does **custodial-first →
  Spark fallback**. `getAccountDefaultWallet` returns `{ id: null }` (instead of
  throwing) when there is no custodial wallet, and `handleSelfCustodialDonate`
  mints the LN-address invoice and polls the LUD-21 verify URL
  (`pollVerifyStatus`). The widget carries a behaviour-identical **inline copy**
  of the helpers so existing single-`<script>` embeds need nothing new. Version
  bumped 1.2.3 → 1.3.0.
- **`js/generator.js`** — username validation falls back to an LNURL
  `.well-known` probe so self-custodial usernames validate in the generator.
- **Tests + CI (new for this repo)** — Vitest + jsdom, 32 tests covering the
  helpers, inline-vs-canonical parity (drift guard), the custodial probe,
  non-Blink-domain rejection (no network call), and amount bounds. A new GitHub
  Actions workflow runs them on PRs/pushes to `main`.
- **`spark-test.html`** — manual end-to-end test page. README updated.

## Backward compatibility

**Existing widgets in the wild are unaffected.** Deployed embeds load only
`js/blink-pay-button.js` and call `BlinkPayButton.init({...})`; that public API
(options, container, events, DOM) is unchanged. The custodial happy path
(`accountDefaultWallet` → on-behalf-of invoice → WebSocket/GraphQL detection) is
untouched. The only changed behaviour is the **previously-failing** branch (no
custodial wallet / GraphQL error), which now attempts the LNURL fallback instead
of throwing — strictly additive. New files (`blink-lnurl.js`, tests, CI, config)
are not loaded by embeds.

Note: embeds pull the script from GitHub Pages and are not version-pinned, so
merging to `main` redeploys the new code to all sites automatically — hence the
test coverage and the live-payment validation below.

Earmarked as follow-up (not in this PR): tidy the "username not found" error
message for the truly-not-found case (it now surfaces an LNURL-side error rather
than the old "Could not retrieve wallet information").

## Testing

- **Live payment validated in production:** a real donation to the
  self-custodial Spark account `yasar` settled to its Spark BTC wallet and the
  widget showed the success checkmark (custodial-first → no wallet → LN-address
  invoice → LUD-21 verify → success).
- **Default-account behaviour verified:** for a Spark account, switching the
  Blink default account to stablecoin still mints a **sats/BTC** invoice (Spark
  is BTC-only at the LNURL server's provider layer). The "default = Dollar →
  USD" routing applies to custodial accounts only; no widget logic is required
  either way (a bare `username@blink.sv` lets the server route to the user's
  default).
- **Unit tests:** `npm test` → 32 passing. `npm audit` → 0 vulnerabilities
  (dev-only toolchain).

## Notes

- Only `blink.sv` Lightning addresses are accepted; non-Blink domains are
  rejected before any network call.
- Self-custodial (Spark) `verify` is webhook-populated server-side, so
  settlement detection may lag a few seconds vs a synchronous pull — the poll
  loop tolerates this.
