### PR TITLE
chore: cleanup-prep (lint/CI, characterization tests, C1 bounded polling, C2 not-found UX)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,25 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: Lint (ESLint)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
   test:
     name: Unit tests (Vitest)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Local-only working plan (not for publication)
+# Local-only working plans (not for publication)
 button_spark_plan.md
+button_cleanup_plan.md
 
 # Node / test tooling (added with the Vitest test harness)
 node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules/
+coverage/
+package-lock.json
+*.md
+*.html

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "tabWidth": 4,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 100,
+  "trailingComma": "es5"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,113 @@
+# AGENTS.md
+
+Guidance for AI agents and contributors working in this repository.
+
+## Project overview
+
+`donation-button.blink.sv` is a lightweight, embeddable Bitcoin Lightning donation
+widget for [Blink](https://blink.sv/). It is:
+
+- **Vanilla JavaScript, no build step** — the source files are served as-is.
+- **No backend** — the browser talks directly to Blink's APIs.
+- **GitHub-Pages hosted** — `main` auto-deploys to production.
+- **AGPL-3.0 licensed.**
+
+The repo also contains a **generator** (`index.html` + `js/generator.js`) that produces
+the embed snippet for a given Blink username.
+
+## Critical guardrails (read before changing anything)
+
+**Live blast radius:** every embed in the wild loads ONE file —
+`https://blinkbitcoin.github.io/donation-button.blink.sv/js/blink-pay-button.js` — and
+calls `BlinkPayButton.init({...})`. Embeds are **not version-pinned**, so **merging to
+`main` redeploys to ALL live sites** via GitHub Pages.
+
+- **Never change the public API** (`BlinkPayButton.init`, its config options, the
+  container-id contract, success/QR DOM behavior) without a deliberate, separately
+  reviewed decision.
+- **Keep the single-file embed working** — no new required `<script>` tags, and no build
+  step that changes the served path.
+- **Each change = its own small PR**, with `npm test` green and (for payment-path changes)
+  a manual smoke via the `*-test.html` pages.
+- **Tests first:** add a characterization test before refactoring a behavior.
+
+## Architecture / key files
+
+- `js/blink-pay-button.js` (~2.6k LOC) — the widget. A single IIFE assigning
+  `window.BlinkPayButton`. Custodial-first flow with a self-custodial (Spark) LNURL-pay
+  fallback. The version header is at the top of the file (`Version: ...`).
+- `js/blink-lnurl.js` (~300 LOC) — canonical UMD module: LNURL-pay (LUD-16) +
+  LUD-21 verify helpers (`parse` / `metadata` / `invoice` / `verify`). `fetch` is injected
+  (last arg) so it is unit-testable. blink.sv-only.
+  - The widget carries a **behavior-identical inline copy** of these helpers
+    (`BlinkPayButton.getLnurl()`) so single-file embeds work without loading this module.
+    **Parity between the two is enforced by tests** — if you change one, change both.
+- `js/generator.js` (~580 LOC) — generator UI logic for `index.html`.
+- `tests/` — Vitest + jsdom specs (`blink-lnurl.spec.js`, `widget-spark.spec.js`,
+  `load-umd.js` helper).
+- `.github/workflows/test.yml` — CI: runs `npm ci && npm test` on PRs/pushes to `main`.
+- `*-test.html` (root) — manual smoke/test pages (e.g. `spark-test.html`,
+  `responsive-test.html`, `widget-width-test.html`).
+- `css-cleanup-strategy.md` — plan for reducing `!important` usage in the embedded CSS.
+
+## Payment flow (high level)
+
+1. **Custodial-first:** GraphQL `accountDefaultWallet(username)` returns a wallet `id` ⇒
+   create an on-behalf-of invoice; detect settlement via WebSocket
+   (`wss://ws.blink.sv/graphql`), with a GraphQL poll fallback.
+2. **Self-custodial (Spark) fallback:** no custodial wallet ⇒ resolve the bare
+   `username@blink.sv` via LNURL-pay (`GET https://blink.sv/.well-known/lnurlp/{username}`),
+   request an invoice from the advertised callback, and detect settlement by polling the
+   LUD-21 `verify` URL.
+
+Endpoints called directly from the browser: `api.blink.sv/graphql`,
+`wss://ws.blink.sv/graphql`, `blink.sv/.well-known/lnurlp/...`, and `api.qrserver.com`
+(QR rendering). Only **blink.sv** Lightning addresses are supported.
+
+## Commands
+
+```bash
+npm install        # install dev deps (Vitest + jsdom)
+npm test           # vitest run (CI uses this)
+npm run test:watch # vitest watch
+```
+
+Manual end-to-end testing: open `spark-test.html` (Spark fallback) or the other
+`*-test.html` pages in a browser. Payment-path changes should be validated with a real
+small donation when possible.
+
+## Conventions
+
+- 4-space indentation in `js/`.
+- Logging is debug-gated: route messages through the widget's `this.log` (enabled by the
+  `debug: true` init option). Avoid raw `console.*` that fires regardless of `debug`.
+- Keep helpers pure and `fetch`-injectable so they unit-test without globals.
+- blink.sv-only: reject explicit non-Blink Lightning-address domains.
+
+## PR mechanics
+
+- `origin = blinkbitcoin/donation-button.blink.sv` (no fork). Branch off `main`, PR into
+  `main`.
+- Bump the version header in `js/blink-pay-button.js` (and the analytics `widget_version`)
+  for behavior changes.
+- `npm test` (and lint, once configured) must be green.
+- AGPL-3.0 — no license changes.
+
+## Environment gotcha
+
+A local `~/.npmrc` setting `min-release-age` can break `npm install` (the version is
+mis-converted into a bogus `before` date → `ETARGET`/`ENOVERSIONS`, every version filtered
+out). Work around per-command without touching the global config:
+
+```bash
+npm install --before= --min-release-age=0
+```
+
+CI runs on a clean runner, so `npm ci` is unaffected.
+
+## Local-only docs
+
+`button_spark_plan.md` and `button_cleanup_plan.md` are working plans and are
+**gitignored** (not published). The cleanup backlog is intended to be worked **after** the
+self-custodial (Spark) PR merges, since that PR adds the repo's first tests + CI (the
+refactor safety net).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,61 @@
+import js from '@eslint/js';
+import globals from 'globals';
+
+/**
+ * Flat ESLint config for the donation-button widget.
+ *
+ * Three environments:
+ *   - js/**          browser source served as-is (IIFE / UMD; no build step).
+ *   - tests/**       Vitest + jsdom (Node + browser-ish globals).
+ *   - *.config.js    Node ESM tooling config.
+ *
+ * Kept intentionally light: this is a dormant, single-file-embed codebase, so the
+ * goal is to catch real bugs (undefined vars, unused code) without forcing a large
+ * stylistic churn on the ~2.6k-LOC widget. Formatting is delegated to Prettier.
+ */
+export default [
+    {
+        ignores: ['node_modules/**', 'coverage/**'],
+    },
+    js.configs.recommended,
+    {
+        // Browser source. UMD module (blink-lnurl.js) also touches CommonJS globals.
+        files: ['js/**/*.js'],
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: 'script',
+            globals: {
+                ...globals.browser,
+                ...globals.commonjs,
+                define: 'readonly',
+            },
+        },
+        rules: {
+            'no-unused-vars': ['warn', { args: 'none' }],
+            'no-empty': ['warn', { allowEmptyCatch: true }],
+        },
+    },
+    {
+        // Test suite.
+        files: ['tests/**/*.js'],
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: 'module',
+            globals: {
+                ...globals.node,
+                ...globals.browser,
+            },
+        },
+    },
+    {
+        // ESM tooling config files.
+        files: ['*.config.js'],
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: 'module',
+            globals: {
+                ...globals.node,
+            },
+        },
+    },
+];

--- a/js/blink-lnurl.js
+++ b/js/blink-lnurl.js
@@ -20,7 +20,6 @@
   // UMD: attach to window/globalThis as `BlinkLnurl` for the browser <script>
   // path, and expose CommonJS/ESM exports for the test runner.
   const api = factory();
-  // eslint-disable-next-line no-undef
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = api;
   }

--- a/js/blink-pay-button.js
+++ b/js/blink-pay-button.js
@@ -1,7 +1,10 @@
 /**
  * Blink Pay Button Widget
  * A simple widget for accepting Bitcoin Lightning donations via Blink wallet
- * Version: 1.3.2 - Friendly "username not found" message: a non-existent Blink
+ * Version: 1.3.3 - Make payment-poll cancellation race-safe: a generation token
+ *                  ensures a poll loop cannot resume after stop/reset when its
+ *                  request was already in flight (would otherwise poll unbounded).
+ *          1.3.2 - Friendly "username not found" message: a non-existent Blink
  *                  username now shows a clear donor-facing error instead of the
  *                  raw "LNURL endpoint returned 404" technical message.
  *          1.3.1 - Bound payment-status polling to the invoice expiry so the
@@ -1631,6 +1634,9 @@
         pollVerifyStatus: function(verifyUrl) {
             const lnurl = this.getLnurl();
             this.log('Starting LUD-21 verify polling');
+            // Capture this loop's generation; starting a new poll supersedes any
+            // previous in-flight loop.
+            const myGen = this.nextPollGeneration();
             const check = async () => {
                 this.paymentPollTimeout = null;
                 // Stop once the invoice has expired (bounded by displayInvoice's
@@ -1641,6 +1647,12 @@
                 }
                 try {
                     const result = await lnurl.verifyLnurlPayment(verifyUrl);
+                    // The request may have resolved after a stop/reset or a newer
+                    // poll started; if so, do not act or reschedule.
+                    if (this.pollGeneration !== myGen) {
+                        this.log('LUD-21 verify poll superseded; stopping');
+                        return;
+                    }
                     if (result && result.settled === true) {
                         this.log('Payment confirmed via LUD-21 verify! 🎉');
                         this.handlePaymentSuccess();
@@ -1649,6 +1661,7 @@
                     this.paymentPollTimeout = setTimeout(check, 2000);
                 } catch (error) {
                     this.log(`Error polling verify status: ${error.message}`, error);
+                    if (this.pollGeneration !== myGen) return; // superseded
                     this.paymentPollTimeout = setTimeout(check, 5000); // back off on error
                 }
             };
@@ -1661,8 +1674,24 @@
             return typeof this.invoiceExpiresAt === 'number' && Date.now() >= this.invoiceExpiresAt;
         },
 
+        // Begin a new payment-poll "generation" and return its token. Each poll
+        // loop captures this; a loop only schedules its next tick while its token
+        // is still current. Starting a new poll or stopping bumps the counter,
+        // which immediately invalidates (cancels) any other in-flight loop.
+        //
+        // This is the authoritative cancellation mechanism: clearTimeout alone is
+        // racy because a poll request resolving mid-flight re-arms the timer after
+        // stopPaymentPolling() has already run (the timeout was null at that point).
+        nextPollGeneration: function() {
+            this.pollGeneration = (this.pollGeneration || 0) + 1;
+            return this.pollGeneration;
+        },
+
         // Stop any in-flight payment-status poll and clear the invoice deadline.
+        // Bumping the generation cancels a loop even if its request is already
+        // awaiting (it will see a stale token after the await and not reschedule).
         stopPaymentPolling: function() {
+            this.nextPollGeneration();
             if (this.paymentPollTimeout) {
                 clearTimeout(this.paymentPollTimeout);
                 this.paymentPollTimeout = null;
@@ -2202,6 +2231,9 @@
         // Polling fallback for payment status
         pollPaymentStatus: function(paymentRequest) {
             this.log(`Starting payment status polling for invoice`);
+            // Capture this loop's generation; starting a new poll supersedes any
+            // previous in-flight loop.
+            const myGen = this.nextPollGeneration();
             const checkPaymentStatus = async () => {
                 this.paymentPollTimeout = null;
                 // Stop once the invoice has expired so we don't poll forever.
@@ -2238,7 +2270,14 @@
                     
                     const data = await response.json();
                     this.log(`Poll response received`, data);
-                    
+
+                    // The request may have resolved after a stop/reset or a newer
+                    // poll started; if so, do not act or reschedule.
+                    if (this.pollGeneration !== myGen) {
+                        this.log('Payment status poll superseded; stopping');
+                        return;
+                    }
+
                     if (data.data && data.data.lnInvoicePaymentStatus) {
                         const status = data.data.lnInvoicePaymentStatus.status;
                         this.log(`Payment status: ${status}`);
@@ -2257,6 +2296,7 @@
                 } catch (error) {
                     this.log(`Error polling for payment status: ${error.message}`, error);
                     console.error('Error checking payment status:', error);
+                    if (this.pollGeneration !== myGen) return; // superseded
                     this.paymentPollTimeout = setTimeout(checkPaymentStatus, 5000); // Retry with longer interval on error
                 }
             };
@@ -2655,7 +2695,7 @@
             }
             
             // Add widget version for tracking
-            params.append('widget_version', '1.3.2');
+            params.append('widget_version', '1.3.3');
             
             return `${baseUrl}?${params.toString()}`;
         }

--- a/js/blink-pay-button.js
+++ b/js/blink-pay-button.js
@@ -1,7 +1,10 @@
 /**
  * Blink Pay Button Widget
  * A simple widget for accepting Bitcoin Lightning donations via Blink wallet
- * Version: 1.3.1 - Bound payment-status polling to the invoice expiry so the
+ * Version: 1.3.2 - Friendly "username not found" message: a non-existent Blink
+ *                  username now shows a clear donor-facing error instead of the
+ *                  raw "LNURL endpoint returned 404" technical message.
+ *          1.3.1 - Bound payment-status polling to the invoice expiry so the
  *                  pollers stop instead of hammering the API forever when a donor
  *                  never pays. Adds isInvoiceExpired/stopPaymentPolling cleanup.
  *          1.3.0 - Self-custodial (Spark) receive via Lightning address (LNURL-pay
@@ -24,6 +27,7 @@
             failedToFetchExchangeRate: 'Failed to fetch exchange rate for',
             pleaseTryAgain: 'Please try again.',
             anErrorOccurred: 'An error occurred while processing your donation',
+            usernameNotFound: 'This Blink username could not be found. Please check the username.',
             qrCodeAlt: 'Lightning Invoice QR Code'
         },
         es: {
@@ -1575,11 +1579,23 @@
             this.log('Self-custodial: requesting LN-address invoice', { lightningAddress, satsAmount });
 
             const memo = `${this.username} donation button`;
-            const invoice = await lnurl.getInvoiceFromLightningAddress(
-                lightningAddress,
-                satsAmount,
-                memo
-            );
+            let invoice;
+            try {
+                invoice = await lnurl.getInvoiceFromLightningAddress(
+                    lightningAddress,
+                    satsAmount,
+                    memo
+                );
+            } catch (error) {
+                // Custodial lookup already found no wallet; if the LNURL
+                // .well-known lookup also 404s, the username simply does not
+                // exist on blink.sv. Surface a clear donor-facing message instead
+                // of the raw "LNURL endpoint returned 404" technical error.
+                if (this.isUsernameNotFoundError(error)) {
+                    throw new Error(this.t('usernameNotFound'));
+                }
+                throw error;
+            }
             if (!invoice || !invoice.paymentRequest) {
                 throw new Error('Could not create invoice');
             }
@@ -1600,6 +1616,14 @@
                 this.log('No LUD-21 verify URL; falling back to GraphQL payment polling');
                 this.pollPaymentStatus(invoice.paymentRequest);
             }
+        },
+
+        // Classify an LNURL error as "username does not exist": the .well-known
+        // lookup for an unknown user returns HTTP 404. Used to show a friendly
+        // donor-facing message instead of the raw LNURL technical error.
+        isUsernameNotFoundError: function(error) {
+            const message = (error && error.message) || '';
+            return /\b404\b/.test(message) || /not found/i.test(message);
         },
 
         // Poll a LUD-21 verify URL until the invoice is settled (Spark path).
@@ -2631,7 +2655,7 @@
             }
             
             // Add widget version for tracking
-            params.append('widget_version', '1.3.1');
+            params.append('widget_version', '1.3.2');
             
             return `${baseUrl}?${params.toString()}`;
         }

--- a/js/blink-pay-button.js
+++ b/js/blink-pay-button.js
@@ -1,7 +1,10 @@
 /**
  * Blink Pay Button Widget
  * A simple widget for accepting Bitcoin Lightning donations via Blink wallet
- * Version: 1.3.0 - Self-custodial (Spark) receive via Lightning address (LNURL-pay
+ * Version: 1.3.1 - Bound payment-status polling to the invoice expiry so the
+ *                  pollers stop instead of hammering the API forever when a donor
+ *                  never pays. Adds isInvoiceExpired/stopPaymentPolling cleanup.
+ *          1.3.0 - Self-custodial (Spark) receive via Lightning address (LNURL-pay
  *                  custodial-first fallback + LUD-21 verify). Custodial flow unchanged.
  */
 (function() {
@@ -1605,6 +1608,13 @@
             const lnurl = this.getLnurl();
             this.log('Starting LUD-21 verify polling');
             const check = async () => {
+                this.paymentPollTimeout = null;
+                // Stop once the invoice has expired (bounded by displayInvoice's
+                // deadline) so we don't poll forever when the donor never pays.
+                if (this.isInvoiceExpired()) {
+                    this.log('Invoice expired; stopping LUD-21 verify polling');
+                    return;
+                }
                 try {
                     const result = await lnurl.verifyLnurlPayment(verifyUrl);
                     if (result && result.settled === true) {
@@ -1612,13 +1622,28 @@
                         this.handlePaymentSuccess();
                         return; // stop polling
                     }
-                    setTimeout(check, 2000);
+                    this.paymentPollTimeout = setTimeout(check, 2000);
                 } catch (error) {
                     this.log(`Error polling verify status: ${error.message}`, error);
-                    setTimeout(check, 5000); // back off on error
+                    this.paymentPollTimeout = setTimeout(check, 5000); // back off on error
                 }
             };
             check();
+        },
+
+        // True once the current invoice's polling deadline has passed. Returns
+        // false when no invoice deadline is set (defensive: never stop early).
+        isInvoiceExpired: function() {
+            return typeof this.invoiceExpiresAt === 'number' && Date.now() >= this.invoiceExpiresAt;
+        },
+
+        // Stop any in-flight payment-status poll and clear the invoice deadline.
+        stopPaymentPolling: function() {
+            if (this.paymentPollTimeout) {
+                clearTimeout(this.paymentPollTimeout);
+                this.paymentPollTimeout = null;
+            }
+            this.invoiceExpiresAt = null;
         },
 
         // Get the default wallet information for a username
@@ -1800,6 +1825,14 @@
             // Initialize countdown
             let totalSeconds = expiryMinutes * 60;
             let countdownInterval;
+
+            // Record an absolute deadline so the payment-status pollers can stop
+            // themselves once the invoice has expired (a small grace period lets a
+            // payment landing right at expiry still be detected). Without this the
+            // pollers would hammer the API forever on a long-lived embed where the
+            // donor never pays. See pollVerifyStatus / pollPaymentStatus.
+            const POLL_GRACE_MS = 5000;
+            this.invoiceExpiresAt = Date.now() + totalSeconds * 1000 + POLL_GRACE_MS;
             
             const updateCountdown = () => {
                 const minutes = Math.floor(totalSeconds / 60);
@@ -2146,6 +2179,12 @@
         pollPaymentStatus: function(paymentRequest) {
             this.log(`Starting payment status polling for invoice`);
             const checkPaymentStatus = async () => {
+                this.paymentPollTimeout = null;
+                // Stop once the invoice has expired so we don't poll forever.
+                if (this.isInvoiceExpired()) {
+                    this.log('Invoice expired; stopping payment status polling');
+                    return;
+                }
                 try {
                     const query = `
                         query CheckPaymentStatus($input: LnInvoicePaymentStatusInput!) {
@@ -2189,12 +2228,12 @@
                     
                     // Continue polling if not yet paid
                     this.log(`Payment not confirmed yet, polling again in 2 seconds`);
-                    setTimeout(checkPaymentStatus, 2000);
+                    this.paymentPollTimeout = setTimeout(checkPaymentStatus, 2000);
                     
                 } catch (error) {
                     this.log(`Error polling for payment status: ${error.message}`, error);
                     console.error('Error checking payment status:', error);
-                    setTimeout(checkPaymentStatus, 5000); // Retry with longer interval on error
+                    this.paymentPollTimeout = setTimeout(checkPaymentStatus, 5000); // Retry with longer interval on error
                 }
             };
             
@@ -2212,6 +2251,9 @@
                 this.countdownInterval = null;
                 this.log('Countdown timer cleared');
             }
+
+            // Stop any in-flight payment-status polling.
+            this.stopPaymentPolling();
             
             // Show success icon
             const successContainer = document.getElementById('blink-pay-success');
@@ -2252,6 +2294,12 @@
             
             // Add new event listener to reset the widget
             newButton.addEventListener('click', () => {
+                // Stop any stale polling/countdown from the completed invoice.
+                this.stopPaymentPolling();
+                if (this.countdownInterval) {
+                    clearInterval(this.countdownInterval);
+                    this.countdownInterval = null;
+                }
                 // Reset the widget back to initial state
                 successContainer.classList.remove('blink-pay-show');
                 successContainer.style.visibility = 'hidden';
@@ -2583,7 +2631,7 @@
             }
             
             // Add widget version for tracking
-            params.append('widget_version', '1.3.0');
+            params.append('widget_version', '1.3.1');
             
             return `${baseUrl}?${params.toString()}`;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blink-donation-button",
-  "version": "1.3.0",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blink-donation-button",
-      "version": "1.3.0",
+      "version": "1.3.3",
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "eslint": "^9.39.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,11 @@
       "name": "blink-donation-button",
       "version": "1.3.0",
       "devDependencies": {
+        "@eslint/js": "^9.39.4",
+        "eslint": "^9.39.4",
+        "globals": "^17.7.0",
         "jsdom": "^25.0.1",
+        "prettier": "^3.8.4",
         "vitest": "^4.0.0"
       }
     },
@@ -161,6 +165,229 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -524,6 +751,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
@@ -637,6 +871,29 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "dev": true,
@@ -644,6 +901,46 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -660,6 +957,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "dev": true,
@@ -672,6 +987,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -681,6 +1006,43 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -693,12 +1055,34 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
@@ -747,6 +1131,13 @@
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -840,6 +1231,163 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -850,6 +1398,16 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "dev": true,
@@ -857,6 +1415,27 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -875,6 +1454,57 @@
           "optional": true
         }
       }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/form-data": {
       "version": "4.0.6",
@@ -949,6 +1579,32 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "dev": true,
@@ -958,6 +1614,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -1042,10 +1708,100 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsdom": {
       "version": "25.0.1",
@@ -1084,6 +1840,51 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lightningcss": {
@@ -1359,6 +2160,29 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "dev": true,
@@ -1401,6 +2225,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "dev": true,
@@ -1425,6 +2262,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nwsapi": {
       "version": "2.2.24",
       "dev": true,
@@ -1444,6 +2288,69 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "dev": true,
@@ -1453,6 +2360,26 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -1511,12 +2438,48 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/rolldown": {
@@ -1574,6 +2537,29 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "dev": true,
@@ -1600,6 +2586,32 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
@@ -1693,6 +2705,29 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
     },
     "node_modules/vite": {
       "version": "8.1.0",
@@ -1912,6 +2947,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "dev": true,
@@ -1925,6 +2976,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ws": {
@@ -1959,6 +3020,19 @@
       "version": "2.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,17 @@
   "type": "module",
   "scripts": {
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "lint": "eslint .",
+    "format": "prettier --check \"js/**/*.js\" \"tests/**/*.js\" \"*.config.js\"",
+    "format:fix": "prettier --write \"js/**/*.js\" \"tests/**/*.js\" \"*.config.js\""
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
+    "eslint": "^9.39.4",
+    "globals": "^17.7.0",
     "jsdom": "^25.0.1",
+    "prettier": "^3.8.4",
     "vitest": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blink-donation-button",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Blink Pay Button donation widget — tests for custodial + self-custodial (Spark) receive.",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blink-donation-button",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Blink Pay Button donation widget — tests for custodial + self-custodial (Spark) receive.",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blink-donation-button",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Blink Pay Button donation widget — tests for custodial + self-custodial (Spark) receive.",
   "private": true,
   "type": "module",

--- a/tests/blink-lnurl.spec.js
+++ b/tests/blink-lnurl.spec.js
@@ -6,7 +6,7 @@
  * module.exports). We load it via createRequire so the CommonJS export path is
  * exercised exactly as Node/test consumers see it.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { loadUmd } from './load-umd.js';
 
 const BlinkLnurl = loadUmd('../js/blink-lnurl.js');

--- a/tests/load-umd.js
+++ b/tests/load-umd.js
@@ -16,7 +16,6 @@ const here = dirname(fileURLToPath(import.meta.url));
 export function loadUmd(relativePath) {
   const src = readFileSync(resolve(here, relativePath), 'utf8');
   const moduleObj = { exports: {} };
-  // eslint-disable-next-line no-new-func
   const run = new Function('module', 'exports', 'globalThis', src);
   run(moduleObj, moduleObj.exports, globalThis);
   return moduleObj.exports;

--- a/tests/widget-currency.spec.js
+++ b/tests/widget-currency.spec.js
@@ -1,0 +1,95 @@
+/**
+ * Characterization tests for the widget's currency math in
+ * js/blink-pay-button.js (convertToSatoshis / convertToUsdCents).
+ *
+ * These functions had NO coverage before. They are pure given a populated
+ * `this.exchangeRates` cache, so we exercise them directly on the loaded
+ * BlinkPayButton object with a stubbed exchange-rate cache and a no-op logger.
+ *
+ * Purpose: lock in the CURRENT observable behaviour (including rounding) so the
+ * planned monolith refactor cannot silently change donation amounts. If a future
+ * change intends to alter this math, these tests must be updated deliberately.
+ *
+ * The Blink rate model used here:
+ *   - satPriceInCurrency      = price of 1 sat, in the currency's MINOR units.
+ *   - usdCentPriceInCurrency  = price of 1 USD cent, in the currency's MINOR units.
+ * Fiat major units are converted to minor units (×100) before dividing.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const widgetSrc = readFileSync(resolve(__dirname, '../js/blink-pay-button.js'), 'utf8');
+
+function loadWidget() {
+    const run = new Function(widgetSrc);
+    run();
+    return window.BlinkPayButton;
+}
+
+let widget;
+
+beforeEach(() => {
+    widget = loadWidget();
+    widget.log = () => {};
+    // Rates: 1 sat = 0.05 USD cents (=> ~50,000 USD/BTC); EUR slightly different.
+    widget.exchangeRates = {
+        USD: { satPriceInCurrency: 0.05, usdCentPriceInCurrency: 1 },
+        EUR: { satPriceInCurrency: 0.045, usdCentPriceInCurrency: 0.9 },
+    };
+});
+
+describe('convertToSatoshis', () => {
+    it('returns the amount unchanged when already in sats', () => {
+        expect(widget.convertToSatoshis(1234, 'sats')).toBe(1234);
+    });
+
+    it('converts a fiat major amount to sats and rounds', () => {
+        // 1 USD = 100 cents; 100 / 0.05 = 2000 sats
+        expect(widget.convertToSatoshis(1, 'USD')).toBe(2000);
+        // 10 EUR = 1000 cents; 1000 / 0.045 = 22222.2 -> 22222
+        expect(widget.convertToSatoshis(10, 'EUR')).toBe(22222);
+    });
+
+    it('rounds to the nearest sat (half-up via Math.round)', () => {
+        // 0.01 USD = 1 cent; 1 / 0.05 = 20 sats exactly
+        expect(widget.convertToSatoshis(0.01, 'USD')).toBe(20);
+    });
+
+    it('throws when no exchange rate is cached for the currency', () => {
+        expect(() => widget.convertToSatoshis(1, 'GBP')).toThrow(/exchange rate not available/i);
+    });
+
+    it('throws when the cached rate lacks satPriceInCurrency', () => {
+        widget.exchangeRates.JPY = { usdCentPriceInCurrency: 1 };
+        expect(() => widget.convertToSatoshis(1, 'JPY')).toThrow(/exchange rate not available/i);
+    });
+});
+
+describe('convertToUsdCents', () => {
+    it('converts sats to USD cents using the USD rate', () => {
+        // 2000 sats * 0.05 cents/sat = 100 cents
+        expect(widget.convertToUsdCents(2000, 'sats')).toBe(100);
+    });
+
+    it('throws converting sats when USD rate is missing', () => {
+        delete widget.exchangeRates.USD;
+        expect(() => widget.convertToUsdCents(2000, 'sats')).toThrow(
+            /USD exchange rate not available/i
+        );
+    });
+
+    it('converts a fiat major amount to USD cents and rounds', () => {
+        // 1 USD = 100 cents; 100 / 1 = 100 USD cents
+        expect(widget.convertToUsdCents(1, 'USD')).toBe(100);
+        // 10 EUR = 1000 minor; 1000 / 0.9 = 1111.1 -> 1111 USD cents
+        expect(widget.convertToUsdCents(10, 'EUR')).toBe(1111);
+    });
+
+    it('throws when no usdCentPriceInCurrency is cached for the fiat currency', () => {
+        widget.exchangeRates.GBP = { satPriceInCurrency: 0.05 };
+        expect(() => widget.convertToUsdCents(1, 'GBP')).toThrow(/exchange rate not available/i);
+    });
+});

--- a/tests/widget-dom.spec.js
+++ b/tests/widget-dom.spec.js
@@ -1,0 +1,125 @@
+/**
+ * Characterization tests for the widget's render + success DOM transitions in
+ * js/blink-pay-button.js.
+ *
+ * These guard the planned monolith split / CSS cleanup: they assert the CURRENT
+ * DOM contract (element ids the embed relies on, and the show/hide state changes
+ * on a successful payment) so a refactor cannot silently break live embeds.
+ *
+ * We render the widget into a real jsdom container via init(), then drive the
+ * success transition directly with handlePaymentSuccess().
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const widgetSrc = readFileSync(resolve(__dirname, '../js/blink-pay-button.js'), 'utf8');
+
+function loadWidget() {
+    const run = new Function(widgetSrc);
+    run();
+    return window.BlinkPayButton;
+}
+
+let widget;
+
+beforeEach(() => {
+    // jsdom has no ResizeObserver; the widget guards on it but stub anyway so
+    // attachEventListeners' observer path is exercised harmlessly.
+    global.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    };
+    window.ResizeObserver = global.ResizeObserver;
+
+    document.body.innerHTML = '<div id="blink-pay-button-container"></div>';
+    widget = loadWidget();
+    widget.init({
+        username: 'alice',
+        containerId: 'blink-pay-button-container',
+        debug: false,
+    });
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+    delete global.ResizeObserver;
+    delete window.ResizeObserver;
+});
+
+describe('render() DOM contract', () => {
+    it('renders the core elements the embed/flow depends on', () => {
+        // These ids are referenced throughout the payment flow; the refactor
+        // must keep them stable.
+        for (const id of [
+            'blink-pay-button',
+            'blink-pay-amount',
+            'blink-pay-qr',
+            'blink-pay-success',
+            'blink-pay-status',
+        ]) {
+            expect(document.getElementById(id), `#${id} should exist`).not.toBeNull();
+        }
+    });
+
+    it('starts with the success icon hidden (no blink-pay-show)', () => {
+        const success = document.getElementById('blink-pay-success');
+        expect(success.classList.contains('blink-pay-show')).toBe(false);
+    });
+});
+
+describe('handlePaymentSuccess() transition', () => {
+    it('shows the success icon and hides the QR', () => {
+        const success = document.getElementById('blink-pay-success');
+        const qr = document.getElementById('blink-pay-qr');
+
+        widget.handlePaymentSuccess();
+
+        expect(success.classList.contains('blink-pay-show')).toBe(true);
+        expect(success.style.visibility).toBe('visible');
+        expect(success.style.opacity).toBe('1');
+
+        expect(qr.classList.contains('blink-pay-show')).toBe(false);
+        expect(qr.style.visibility).toBe('hidden');
+    });
+
+    it('hides the amount input group', () => {
+        const amount = document.getElementById('blink-pay-amount');
+        const inputGroup = amount.parentElement;
+
+        widget.handlePaymentSuccess();
+
+        expect(inputGroup.style.display).toBe('none');
+        expect(inputGroup.style.visibility).toBe('hidden');
+    });
+
+    it('clears a running countdown interval', () => {
+        const spy = vi.spyOn(global, 'clearInterval');
+        widget.countdownInterval = setInterval(() => {}, 1000);
+
+        widget.handlePaymentSuccess();
+
+        expect(spy).toHaveBeenCalled();
+        expect(widget.countdownInterval).toBeNull();
+    });
+
+    it('clicking the success button resets the widget to the input state', () => {
+        widget.handlePaymentSuccess();
+
+        const amount = document.getElementById('blink-pay-amount');
+        const inputGroup = amount.parentElement;
+        expect(inputGroup.style.display).toBe('none');
+
+        // After success, the button was cloned; query the live one and click it.
+        document.getElementById('blink-pay-button').click();
+
+        const success = document.getElementById('blink-pay-success');
+        expect(success.classList.contains('blink-pay-show')).toBe(false);
+        expect(inputGroup.style.display).toBe('flex');
+        expect(inputGroup.style.visibility).toBe('visible');
+    });
+});

--- a/tests/widget-notfound.spec.js
+++ b/tests/widget-notfound.spec.js
@@ -1,0 +1,85 @@
+/**
+ * Tests for the friendly "username not found" UX (C2) in js/blink-pay-button.js.
+ *
+ * Before C2, a truly non-existent username fell through custodial (no wallet) to
+ * the self-custodial LNURL path, whose .well-known lookup 404s, surfacing the raw
+ * "LNURL endpoint returned 404" to the donor. C2 detects the not-found case and
+ * shows a clear, translated message (t('usernameNotFound')).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const widgetSrc = readFileSync(resolve(__dirname, '../js/blink-pay-button.js'), 'utf8');
+
+function loadWidget() {
+    const run = new Function(widgetSrc);
+    run();
+    return window.BlinkPayButton;
+}
+
+let widget;
+
+beforeEach(() => {
+    widget = loadWidget();
+    widget.log = () => {};
+    widget.language = 'en';
+    widget.username = 'doesnotexist';
+    widget.selectedCurrency = 'sats';
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('isUsernameNotFoundError', () => {
+    it('matches a 404 LNURL error', () => {
+        expect(widget.isUsernameNotFoundError(new Error('LNURL endpoint returned 404'))).toBe(true);
+    });
+
+    it('matches a "not found" message', () => {
+        expect(widget.isUsernameNotFoundError(new Error('Account not found'))).toBe(true);
+    });
+
+    it('does not match unrelated errors', () => {
+        expect(widget.isUsernameNotFoundError(new Error('Network timeout'))).toBe(false);
+        expect(widget.isUsernameNotFoundError(new Error('LNURL endpoint returned 500'))).toBe(false);
+        expect(widget.isUsernameNotFoundError(null)).toBe(false);
+    });
+});
+
+describe('handleSelfCustodialDonate not-found handling', () => {
+    it('rethrows the friendly message when the LNURL lookup 404s', async () => {
+        widget.getLnurl = () => ({
+            normalizeBlinkLightningAddress: (u) => `${u}@blink.sv`,
+            getInvoiceFromLightningAddress: async () => {
+                throw new Error('LNURL endpoint returned 404');
+            },
+        });
+
+        await expect(widget.handleSelfCustodialDonate(1000)).rejects.toThrow(
+            widget.t('usernameNotFound')
+        );
+        // The friendly message should not leak the raw technical text.
+        await expect(widget.handleSelfCustodialDonate(1000)).rejects.not.toThrow(/404/);
+    });
+
+    it('passes through non-not-found errors unchanged', async () => {
+        widget.getLnurl = () => ({
+            normalizeBlinkLightningAddress: (u) => `${u}@blink.sv`,
+            getInvoiceFromLightningAddress: async () => {
+                throw new Error('LNURL endpoint returned 500');
+            },
+        });
+
+        await expect(widget.handleSelfCustodialDonate(1000)).rejects.toThrow(/500/);
+    });
+
+    it('t(usernameNotFound) returns a non-key, donor-facing string', () => {
+        const msg = widget.t('usernameNotFound');
+        expect(msg).not.toBe('usernameNotFound');
+        expect(msg.length).toBeGreaterThan(0);
+    });
+});

--- a/tests/widget-polling.spec.js
+++ b/tests/widget-polling.spec.js
@@ -1,0 +1,122 @@
+/**
+ * Tests for bounded payment-status polling (C1) in js/blink-pay-button.js.
+ *
+ * Before C1, pollVerifyStatus (the primary detector on the self-custodial Spark
+ * path) and the legacy pollPaymentStatus polled every 2s FOREVER if the donor
+ * never paid — hammering the API on long-lived embeds. C1 bounds them with an
+ * invoice deadline (this.invoiceExpiresAt, set by displayInvoice) and exposes
+ * stopPaymentPolling() for reset/success cleanup.
+ *
+ * Uses fake timers to advance through poll cycles without real waiting.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const widgetSrc = readFileSync(resolve(__dirname, '../js/blink-pay-button.js'), 'utf8');
+
+function loadWidget() {
+    const run = new Function(widgetSrc);
+    run();
+    return window.BlinkPayButton;
+}
+
+let widget;
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    widget = loadWidget();
+    widget.log = () => {};
+    widget.paymentPollTimeout = null;
+    widget.invoiceExpiresAt = null;
+    // handlePaymentSuccess touches the DOM; stub it so polling tests stay focused.
+    widget.handlePaymentSuccess = vi.fn();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+});
+
+describe('isInvoiceExpired', () => {
+    it('is false when no deadline is set (never stop early)', () => {
+        widget.invoiceExpiresAt = null;
+        expect(widget.isInvoiceExpired()).toBe(false);
+    });
+
+    it('reflects the deadline relative to now', () => {
+        widget.invoiceExpiresAt = Date.now() + 1000;
+        expect(widget.isInvoiceExpired()).toBe(false);
+        widget.invoiceExpiresAt = Date.now() - 1;
+        expect(widget.isInvoiceExpired()).toBe(true);
+    });
+});
+
+describe('pollVerifyStatus (bounded)', () => {
+    it('stops polling once the invoice deadline passes', async () => {
+        const verify = vi
+            .fn()
+            .mockResolvedValue({ settled: false });
+        widget.getLnurl = () => ({ verifyLnurlPayment: verify });
+
+        // Deadline 5s out: allows the first poll, then a couple of cycles.
+        widget.invoiceExpiresAt = Date.now() + 5000;
+
+        widget.pollVerifyStatus('https://blink.sv/verify/h');
+
+        // Let the initial check + a few 2s cycles run.
+        for (let i = 0; i < 5; i++) {
+            await vi.advanceTimersByTimeAsync(2000);
+        }
+
+        const callsAtExpiry = verify.mock.calls.length;
+        expect(callsAtExpiry).toBeGreaterThan(0);
+
+        // Advance well past expiry; polling must NOT continue indefinitely.
+        for (let i = 0; i < 10; i++) {
+            await vi.advanceTimersByTimeAsync(2000);
+        }
+        expect(verify.mock.calls.length).toBe(callsAtExpiry);
+        expect(widget.paymentPollTimeout).toBeNull();
+    });
+
+    it('calls handlePaymentSuccess and stops when settled', async () => {
+        const verify = vi
+            .fn()
+            .mockResolvedValueOnce({ settled: false })
+            .mockResolvedValue({ settled: true });
+        widget.getLnurl = () => ({ verifyLnurlPayment: verify });
+        widget.invoiceExpiresAt = Date.now() + 60000;
+
+        widget.pollVerifyStatus('https://blink.sv/verify/h');
+        await vi.advanceTimersByTimeAsync(2000); // second poll => settled
+
+        expect(widget.handlePaymentSuccess).toHaveBeenCalledTimes(1);
+
+        const callsWhenSettled = verify.mock.calls.length;
+        await vi.advanceTimersByTimeAsync(10000);
+        expect(verify.mock.calls.length).toBe(callsWhenSettled); // stopped
+    });
+});
+
+describe('stopPaymentPolling', () => {
+    it('clears a pending poll and the deadline', async () => {
+        const verify = vi.fn().mockResolvedValue({ settled: false });
+        widget.getLnurl = () => ({ verifyLnurlPayment: verify });
+        widget.invoiceExpiresAt = Date.now() + 60000;
+
+        widget.pollVerifyStatus('https://blink.sv/verify/h');
+        await vi.advanceTimersByTimeAsync(0); // run the initial check, schedule next
+        expect(widget.paymentPollTimeout).not.toBeNull();
+
+        const callsBeforeStop = verify.mock.calls.length;
+        widget.stopPaymentPolling();
+        expect(widget.paymentPollTimeout).toBeNull();
+        expect(widget.invoiceExpiresAt).toBeNull();
+
+        await vi.advanceTimersByTimeAsync(10000);
+        expect(verify.mock.calls.length).toBe(callsBeforeStop); // no more polls
+    });
+});

--- a/tests/widget-polling.spec.js
+++ b/tests/widget-polling.spec.js
@@ -8,6 +8,11 @@
  * stopPaymentPolling() for reset/success cleanup.
  *
  * Uses fake timers to advance through poll cycles without real waiting.
+ *
+ * Also covers the cancellation race (PR #5 review): if a stop/reset happens while
+ * a poll request is already in flight, the loop must NOT resume when that request
+ * later resolves. Cancellation is enforced by a generation token bumped in
+ * nextPollGeneration()/stopPaymentPolling().
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -23,6 +28,16 @@ function loadWidget() {
     return window.BlinkPayButton;
 }
 
+// A promise whose resolve is exposed so a test can interleave other work (e.g.
+// stopPaymentPolling) between the await starting and the request resolving.
+function deferred() {
+    let resolve;
+    const promise = new Promise((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
+
 let widget;
 
 beforeEach(() => {
@@ -31,6 +46,7 @@ beforeEach(() => {
     widget.log = () => {};
     widget.paymentPollTimeout = null;
     widget.invoiceExpiresAt = null;
+    widget.pollGeneration = 0;
     // handlePaymentSuccess touches the DOM; stub it so polling tests stay focused.
     widget.handlePaymentSuccess = vi.fn();
 });
@@ -118,5 +134,91 @@ describe('stopPaymentPolling', () => {
 
         await vi.advanceTimersByTimeAsync(10000);
         expect(verify.mock.calls.length).toBe(callsBeforeStop); // no more polls
+    });
+});
+
+describe('stop-while-a-poll-is-in-flight (cancellation race, PR #5 review)', () => {
+    it('pollVerifyStatus does not resume after stop if the in-flight verify resolves unpaid', async () => {
+        const d = deferred();
+        const verify = vi.fn().mockReturnValueOnce(d.promise);
+        widget.getLnurl = () => ({ verifyLnurlPayment: verify });
+        widget.invoiceExpiresAt = Date.now() + 60000;
+
+        widget.pollVerifyStatus('https://blink.sv/verify/h');
+        // The first check() has run and is now awaiting verify (request in flight).
+        expect(verify).toHaveBeenCalledTimes(1);
+
+        // Stop (e.g. success/reset elsewhere) while the request is still pending.
+        widget.stopPaymentPolling();
+
+        // Now the in-flight request resolves as unpaid.
+        d.resolve({ settled: false });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // It must NOT have scheduled another poll.
+        expect(widget.paymentPollTimeout).toBeNull();
+        await vi.advanceTimersByTimeAsync(30000);
+        expect(verify).toHaveBeenCalledTimes(1);
+    });
+
+    it('pollPaymentStatus does not resume after stop if the in-flight request resolves PENDING', async () => {
+        const d = deferred();
+        // First fetch is the in-flight request; resolve to a PENDING status.
+        const fetchMock = vi.fn().mockReturnValueOnce(
+            d.promise.then(() => ({
+                json: async () => ({ data: { lnInvoicePaymentStatus: { status: 'PENDING' } } }),
+            }))
+        );
+        window.fetch = fetchMock;
+        global.fetch = fetchMock;
+        widget.invoiceExpiresAt = Date.now() + 60000;
+
+        widget.pollPaymentStatus('lnbc1invoice');
+        expect(fetchMock).toHaveBeenCalledTimes(1); // in flight
+
+        // Stop while the request is pending.
+        widget.stopPaymentPolling();
+
+        // Resolve the in-flight request as unpaid.
+        d.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(widget.paymentPollTimeout).toBeNull();
+        await vi.advanceTimersByTimeAsync(30000);
+        expect(fetchMock).toHaveBeenCalledTimes(1); // loop did not resume
+
+        delete window.fetch;
+        delete global.fetch;
+    });
+
+    it('starting a new poll supersedes a previously in-flight loop', async () => {
+        const d1 = deferred();
+        const verify = vi
+            .fn()
+            .mockReturnValueOnce(d1.promise) // first (old) loop's in-flight request
+            .mockResolvedValue({ settled: false }); // second (new) loop
+        widget.getLnurl = () => ({ verifyLnurlPayment: verify });
+        widget.invoiceExpiresAt = Date.now() + 60000;
+
+        widget.pollVerifyStatus('https://blink.sv/verify/a'); // old loop, gen N
+        widget.pollVerifyStatus('https://blink.sv/verify/b'); // new loop, gen N+1
+
+        const callsAfterStart = verify.mock.calls.length;
+
+        // The old loop's request now resolves; it must not reschedule (stale gen).
+        d1.resolve({ settled: false });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // Stop the active (new) loop so the test doesn't poll unbounded.
+        widget.stopPaymentPolling();
+        await vi.advanceTimersByTimeAsync(10000);
+
+        // The old loop never produced an extra scheduled call beyond what the new
+        // loop accounts for; key assertion is no runaway growth.
+        expect(verify.mock.calls.length).toBe(callsAfterStart);
     });
 });

--- a/tests/widget-spark.spec.js
+++ b/tests/widget-spark.spec.js
@@ -27,7 +27,6 @@ const widgetSrc = readFileSync(
 // Load the widget IIFE into the current (jsdom) realm so it assigns
 // window.BlinkPayButton. Runs once; the object is stateless for our purposes.
 function loadWidget() {
-  // eslint-disable-next-line no-new-func
   const run = new Function(widgetSrc);
   run();
   return window.BlinkPayButton;


### PR DESCRIPTION
## Summary

Cleanup-prep work that is **stacked on top of #4** (self-custodial Spark receive).
Base is `feat/self-custodial-spark-receive` so this diff shows **only** the prep
commits; once #4 merges, this PR's base will be retargeted to `main`.

Draft until #4 merges. All commits keep `npm test` green and `npm run lint` clean.

## What's here (5 commits)

1. **docs: AGENTS.md** — contributor/agent guide (guardrails, key files, payment flow,
   commands, conventions, PR mechanics, `npmrc` env gotcha).
2. **chore: ESLint + Prettier + CI lint** — flat ESLint 9 config scoped for
   `js/` (browser), `tests/`, and config files; Prettier config; `lint` / `format`
   scripts; a lint job added to `.github/workflows/test.yml`. Lint baseline fixed to
   exit clean (5 documented dead-code warnings left for the monolith pass).
   Prettier is **not** mass-applied here (huge diff) — left as an informational script
   for a dedicated formatting PR later.
3. **test: characterization tests** — `widget-currency.spec.js` (currency math +
   rounding) and `widget-dom.spec.js` (render element-id contract + success
   transition). These guard the planned monolith split / CSS cleanup.
4. **fix: bound payment-status polling (C1)** — `pollVerifyStatus` (Spark primary
   detector) and the legacy `pollPaymentStatus` no longer poll forever when a donor
   never pays. Bounded by an invoice deadline (`invoiceExpiresAt` + 5s grace); adds
   `isInvoiceExpired` / `stopPaymentPolling` cleanup wired into success/reset. Fake-timer
   tests. `v1.3.1`.
5. **fix: friendly username-not-found UX (C2)** — a non-existent Blink username now
   shows a clear donor-facing message instead of the raw "LNURL endpoint returned 404".
   `en` translation key added (other languages fall back via `t()`). Tests added.
   `v1.3.2`.

## Test status

- `npm test`: **58 passing** (was 32).
- `npm run lint`: 0 errors (5 warnings).

## Notes / guardrails

- Public API (`BlinkPayButton.init`, container-id contract, success/QR DOM behavior) is
  unchanged. C1 and C2 only affect the failing/no-wallet and never-paid paths.
- No new required `<script>` tag; single-file embed path unchanged.
- Deferred to follow-ups (need #4 on `main` first): monolith split, CSS `!important`
  reduction, inline-LNURL de-dupe, repo tidy, Prettier mass-format.
