### PR TITLE
docs: fix stale README refs + generator a11y/preview nits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Local-only working plans (not for publication)
 button_spark_plan.md
 button_cleanup_plan.md
+tier1_plan.md
 
 # Node / test tooling (added with the Vitest test harness)
 node_modules/

--- a/README.md
+++ b/README.md
@@ -188,40 +188,45 @@ You can customize the appearance with CSS:
 
 ### Prerequisites
 
-- Node.js 16+ and npm
 - A [Blink](https://blink.sv/) account
+- Node.js 18+ and npm (only required to run the tests; the widget itself has no build step)
 
 ### Setup
 
+This is a **static, no-build** project — the source files are served as-is. There is no
+bundler and no backend.
+
 1. Clone the repository:
 ```bash
-git clone https://github.com/pretyflaco/blink-donation-widget.git
-cd blink-donation-widget
+git clone https://github.com/blinkbitcoin/donation-button.blink.sv.git
+cd donation-button.blink.sv
 ```
 
-2. Install dependencies:
+2. Open the generator locally. Either open `index.html` directly in a browser, or serve
+   the directory with any static file server, for example:
+```bash
+python3 -m http.server 8000   # then open http://localhost:8000
+```
+
+3. (Optional) Install dev dependencies to run the test suite:
 ```bash
 npm install
+npm test
 ```
-
-3. Start development server:
-```bash
-npm start
-```
-
-4. Open [http://localhost:3000](http://localhost:3000)
 
 ### Project Structure
 
 ```
-├── public/
-│   ├── index.html              # Widget generator interface
-│   │   ├── js/
-│   │   │   ├── blink-pay-button.js # Main widget code
-│   │   │   └── generator.js        # Generator interface logic
-│   │   └── img/                    # Assets (logos, icons)
-│   ├── package.json                # Dependencies and scripts
-│   └── server.js                   # Development server
+├── index.html                  # Widget generator interface
+├── js/
+│   ├── blink-pay-button.js     # Main widget code (the single embedded file)
+│   ├── blink-lnurl.js          # LNURL-pay (LUD-16) + LUD-21 verify helpers (UMD)
+│   └── generator.js            # Generator interface logic
+├── img/                        # Assets (logos, icons, meta images)
+├── tests/                      # Vitest + jsdom specs
+├── *-test.html                 # Manual smoke/test pages (e.g. spark-test.html)
+├── .github/workflows/          # CI (runs npm ci && npm test)
+├── package.json                # Dev dependencies and test scripts
 └── README.md                   # This file
 ```
 
@@ -260,7 +265,7 @@ This project is licensed under the GNU Affero General Public License v3.0 (AGPL-
 
 ## 📞 Support
 
-- **Issues**: [GitHub Issues](https://github.com/pretyflaco/blink-donation-widget/issues)
+- **Issues**: [GitHub Issues](https://github.com/blinkbitcoin/donation-button.blink.sv/issues)
 - **Documentation**: [Widget Generator](https://blinkbitcoin.github.io/donation-button.blink.sv/)
 - **Blink Support**: [Blink Developer Docs](https://dev.blink.sv/)
 

--- a/index.html
+++ b/index.html
@@ -34,6 +34,9 @@
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://donation-button.blink.sv/">
     
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="img/blink-light.svg">
+    
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>
@@ -320,7 +323,7 @@
 </head>
 <body class="light-mode">
     <div class="theme-switch">
-        <button id="theme-toggle" class="btn btn-sm btn-outline-secondary">
+        <button id="theme-toggle" class="btn btn-sm btn-outline-secondary" aria-label="Switch to dark mode" title="Switch to dark mode">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-moon" viewBox="0 0 16 16">
                 <path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278z"/>
             </svg>

--- a/js/generator.js
+++ b/js/generator.js
@@ -85,6 +85,9 @@ document.addEventListener('DOMContentLoaded', function() {
             if (headerLogo) {
                 headerLogo.src = 'img/blink-light.svg';
             }
+            // Re-apply accessible label after innerHTML swap (now in light mode)
+            themeToggle.setAttribute('aria-label', 'Switch to dark mode');
+            themeToggle.setAttribute('title', 'Switch to dark mode');
         } else {
             body.classList.remove('light-mode');
             body.classList.add('dark-mode');
@@ -92,6 +95,9 @@ document.addEventListener('DOMContentLoaded', function() {
             if (headerLogo) {
                 headerLogo.src = 'img/blink-dark.svg';
             }
+            // Re-apply accessible label after innerHTML swap (now in dark mode)
+            themeToggle.setAttribute('aria-label', 'Switch to light mode');
+            themeToggle.setAttribute('title', 'Switch to light mode');
         }
     });
     
@@ -572,6 +578,22 @@ document.addEventListener('DOMContentLoaded', function() {
                 this.dispatchEvent(new Event('input', { bubbles: true }));
             }, 500); // 500ms delay
         }
+
+        // Live preview: once the user has generated at least once (result is visible),
+        // keep the preview and generated code in sync as the username changes.
+        // This is a local-only refresh — the async existence check stays gated behind
+        // Generate / Enter, so we don't hit the network on every keystroke.
+        if (resultContainer.style.display === 'block') {
+            clearTimeout(this.previewTimeout);
+            this.previewTimeout = setTimeout(() => {
+                const nextUsername = cleanUsernameInput(blinkUsernameInput.value);
+                if (nextUsername && nextUsername !== currentUsername) {
+                    currentUsername = nextUsername;
+                    updateGeneratedCode();
+                    updateWidgetPreview();
+                }
+            }, 500);
+        }
     });
     
     // Button width input event listener
@@ -579,5 +601,6 @@ document.addEventListener('DOMContentLoaded', function() {
         const value = parseInt(this.value);
         currentButtonWidth = value && value >= 200 && value <= 500 ? value : null;
         updateWidgetPreview();
+        updateGeneratedCode();
     });
 }); 


### PR DESCRIPTION
## Summary

Tier 1 maintenance from the project review: documentation accuracy + small generator UX/a11y nits. **No changes to `js/blink-pay-button.js`** (the single file every live embed loads), so zero blast radius on production embeds and no version bump.

## Changes

**README.md** — fix stale references:
- Clone URL/dir → `blinkbitcoin/donation-button.blink.sv` (was `pretyflaco/blink-donation-widget`)
- Replace fictional `npm start` / localhost:3000 dev-server steps with the real **no-build** workflow (open `index.html` or static-serve; `npm install`/`npm test` for tests only)
- Rewrite Project Structure to match reality (remove non-existent `public/` and `server.js`; add `tests/`, `blink-lnurl.js`, `*-test.html`, `.github/workflows/`)
- Fix issues link → `blinkbitcoin/...`

**index.html**
- Add SVG favicon (`img/blink-light.svg`)
- Add `aria-label`/`title` to the theme toggle button

**js/generator.js**
- Re-apply the toggle's `aria-label`/`title` after each icon swap, reflecting the next action so the label survives toggling
- Username **live preview**: debounced (500ms) refresh of preview + generated code on username edits, gated on the result being visible — **no per-keystroke network call** (the async existence check stays on Generate/Enter)
- Fix button-width handler to also call `updateGeneratedCode()` so code and preview stay in sync

## Out of scope (left untouched)
- The QR external-API and embedder-callback items (Tier 2) and version-pinning/SRI (Tier 3) — separate follow-ups.
- Pre-existing lint/prettier warnings in `generator.js` (confirmed present before these edits).

## Testing
- `npm test`: **61/61 pass**
- Manual: favicon renders; toggle exposes/updates `aria-label`; typing a username live-updates preview + code without firing the network check per keystroke; Generate/Enter still validates existence; width changes update both preview and code.