### PR TITLE
feat: add embedder lifecycle callbacks (onSuccess/onError/onTimeout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,36 @@ Your widget is now live and ready to receive Bitcoin Lightning donations!
 | `defaultAmount` | number | `1000` | Default amount in sats |
 | `buttonWidth` | number | `null` | Custom button width in pixels (200-500px) |
 | `supportedCurrencies` | array | `[sats, USD]` | Array of currency objects |
+| `onSuccess` | function | `null` | Called when a donation is paid. Receives `{ username, amount, currency, paymentRequest }` |
+| `onError` | function | `null` | Called when a donation attempt fails. Receives `{ error, message }` |
+| `onTimeout` | function | `null` | Called when the displayed invoice expires unpaid. Receives `{ paymentRequest }` |
 | `debug` | boolean | `false` | Enable console logging |
+
+### Lifecycle Callbacks
+
+The optional `onSuccess`, `onError`, and `onTimeout` callbacks let the embedding site
+react to donation events (e.g. analytics, thank-you UI, or error monitoring). They are
+additive and entirely optional — omitting them changes nothing. A handler that throws is
+caught internally and never breaks the widget.
+
+```javascript
+BlinkPayButton.init({
+  username: 'your-blink-username',
+  containerId: 'blink-pay-button-container',
+  onSuccess: ({ username, amount, currency, paymentRequest }) => {
+    console.log(`Received ${amount} ${currency} for ${username}`);
+  },
+  onError: ({ message }) => {
+    console.warn('Donation failed:', message);
+  },
+  onTimeout: ({ paymentRequest }) => {
+    console.log('Invoice expired unpaid:', paymentRequest);
+  }
+});
+```
+
+> Note: `amount`/`currency` in the `onSuccess` payload reflect the donor's selected display
+> amount and currency at request time.
 
 ### Currency Configuration
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Your widget is now live and ready to receive Bitcoin Lightning donations!
 | `buttonWidth` | number | `null` | Custom button width in pixels (200-500px) |
 | `supportedCurrencies` | array | `[sats, USD]` | Array of currency objects |
 | `onSuccess` | function | `null` | Called when a donation is paid. Receives `{ username, amount, currency, paymentRequest }` |
-| `onError` | function | `null` | Called when a donation attempt fails. Receives `{ error, message }` |
+| `onError` | function | `null` | Called when a donation attempt fails (e.g. invoice creation or exchange-rate lookup). Receives `{ error, message }`. Input-validation errors (invalid/too-small amount) are surfaced in the UI only and do not fire this callback |
 | `onTimeout` | function | `null` | Called when the displayed invoice expires unpaid. Receives `{ paymentRequest }` |
 | `debug` | boolean | `false` | Enable console logging |
 
@@ -84,6 +84,10 @@ The optional `onSuccess`, `onError`, and `onTimeout` callbacks let the embedding
 react to donation events (e.g. analytics, thank-you UI, or error monitoring). They are
 additive and entirely optional — omitting them changes nothing. A handler that throws is
 caught internally and never breaks the widget.
+
+`onError` fires for failed donation *attempts* — invoice creation or exchange-rate
+lookup failures. Input-validation problems (an invalid or too-small amount) are shown in
+the widget UI only and intentionally do **not** trigger `onError`.
 
 ```javascript
 BlinkPayButton.init({

--- a/analytics-test.html
+++ b/analytics-test.html
@@ -93,6 +93,15 @@
         </div>
 
         <div class="analytics-demo">
+            <h3>🪝 Lifecycle Callback Log</h3>
+            <p>The live widget below wires <code>onSuccess</code>, <code>onError</code>, and
+               <code>onTimeout</code>. Events appear here (and in the console) as you interact.
+               To smoke-test <code>onSuccess</code>, pay the generated invoice with a real
+               wallet; <code>onTimeout</code> fires if you let the invoice expire.</p>
+            <div id="callbackLog" class="url-display">No callback events yet…</div>
+        </div>
+
+        <div class="analytics-demo">
             <h3>ℹ️ What Gets Tracked</h3>
             <ul>
                 <li><strong>Username:</strong> The Blink username configured in the widget</li>
@@ -146,6 +155,19 @@
             }
         }
 
+        // Append a line to the on-page callback log (and the console).
+        function logCallback(name, payload) {
+            const el = document.getElementById('callbackLog');
+            const time = new Date().toLocaleTimeString();
+            const line = `[${time}] ${name}: ${JSON.stringify(payload)}`;
+            if (el.textContent === 'No callback events yet…') {
+                el.textContent = line;
+            } else {
+                el.textContent += '\n' + line;
+            }
+            console.log('[callback]', name, payload);
+        }
+
         // Initialize the live widget demo
         document.addEventListener('DOMContentLoaded', () => {
             BlinkPayButton.init({
@@ -157,6 +179,9 @@
                     { code: 'sats', name: 'sats', isCrypto: true },
                     { code: 'USD', name: 'USD', isCrypto: false }
                 ],
+                onSuccess: (payload) => logCallback('onSuccess', payload),
+                onError: (payload) => logCallback('onError', { message: payload && payload.message }),
+                onTimeout: (payload) => logCallback('onTimeout', payload),
                 debug: true
             });
         });

--- a/js/blink-pay-button.js
+++ b/js/blink-pay-button.js
@@ -1,7 +1,11 @@
 /**
  * Blink Pay Button Widget
  * A simple widget for accepting Bitcoin Lightning donations via Blink wallet
- * Version: 1.3.3 - Make payment-poll cancellation race-safe: a generation token
+ * Version: 1.4.0 - Optional embedder lifecycle callbacks (onSuccess/onError/
+ *                  onTimeout). Additive only; existing public API unchanged.
+ *                  Callbacks are invoked via a try/catch-wrapped fireCallback so a
+ *                  throwing embedder handler can never break the widget.
+ *          1.3.3 - Make payment-poll cancellation race-safe: a generation token
  *                  ensures a poll loop cannot resume after stop/reset when its
  *                  request was already in flight (would otherwise poll unbounded).
  *          1.3.2 - Friendly "username not found" message: a non-existent Blink
@@ -614,6 +618,13 @@
             this.buttonWidth = config.buttonWidth || null; // Custom button width in pixels
             this.container = document.getElementById(this.containerId);
             this.debug = config.debug || false;
+
+            // Optional embedder lifecycle callbacks. Non-functions are ignored so a
+            // bad value can never throw. Invoked via fireCallback() (try/catch-wrapped)
+            // so a throwing embedder handler can't break the widget.
+            this.onSuccess = typeof config.onSuccess === 'function' ? config.onSuccess : null;
+            this.onError = typeof config.onError === 'function' ? config.onError : null;
+            this.onTimeout = typeof config.onTimeout === 'function' ? config.onTimeout : null;
             this.logs = [];
             this.selectedCurrency = 'sats'; // Default currency
             this.exchangeRates = {}; // Cache for exchange rates (currency -> rate)
@@ -666,7 +677,20 @@
             this.logs.push(logEntry);
             console.log(`[BlinkPay ${timestamp}]`, message, data || '');
         },
-        
+
+        // Safely invoke an optional embedder callback (onSuccess/onError/onTimeout).
+        // Any error thrown by the embedder's handler is caught and logged so it can
+        // never break the widget's own flow.
+        fireCallback: function(name, payload) {
+            const cb = this[name];
+            if (typeof cb !== 'function') return;
+            try {
+                cb(payload);
+            } catch (err) {
+                this.log(`Embedder ${name} callback threw`, err);
+            }
+        },
+
         // Render the widget in the container
         render: function() {
             // Blink logos for both light and dark modes with absolute URLs
@@ -1405,6 +1429,10 @@
                     }
                 }
                 
+                // Stash the donation context for embedder callbacks. The selected
+                // currency/amount are not otherwise in scope at settlement time.
+                this.lastDonation = { amount, currency: this.selectedCurrency };
+
                 // Clear any previous status messages and start loading
                 this.showStatus('', '');
                 this.setButtonLoading(true);
@@ -1470,6 +1498,7 @@
                     console.error('Blink Pay Button Error:', error);
                     this.showStatus('error', error.message || this.t('anErrorOccurred'));
                     this.setButtonLoading(false);
+                    this.fireCallback('onError', { error, message: error.message });
                 }
             } catch (topLevelError) {
                 console.error('Top-level error in handleDonate:', topLevelError);
@@ -1477,6 +1506,7 @@
                 console.error('Widget context:', this);
                 this.showStatus('error', `Debug error: ${topLevelError.message}`);
                 this.setButtonLoading(false);
+                this.fireCallback('onError', { error: topLevelError, message: topLevelError.message });
             }
         },
         
@@ -1844,6 +1874,13 @@
         
         // Display the invoice and QR code
         displayInvoice: function(paymentRequest, expiryMinutes) {
+            // Stash for embedder callbacks (onSuccess/onTimeout payloads).
+            this.currentPaymentRequest = paymentRequest;
+            // Reset the per-invoice guards so onTimeout/onSuccess can each fire once
+            // for this invoice (and again for a subsequent donation in the session).
+            this.timeoutFired = false;
+            this.successFired = false;
+
             const qrContainer = document.getElementById('blink-pay-qr');
             const successContainer = document.getElementById('blink-pay-success');
             const amountInput = document.getElementById('blink-pay-amount');
@@ -1898,6 +1935,11 @@
                     countdownElement.style.color = '#c62828 !important';
                     countdownElement.textContent = '0:00';
                     this.log('Invoice expired');
+                    // Notify the embedder once that the invoice timed out unpaid.
+                    if (!this.timeoutFired) {
+                        this.timeoutFired = true;
+                        this.fireCallback('onTimeout', { paymentRequest: this.currentPaymentRequest });
+                    }
                 } else {
                     totalSeconds--;
                 }
@@ -2389,6 +2431,20 @@
                 // Clear the status
                 this.showStatus('', '');
             });
+
+            // Notify the embedder of the successful donation. Guarded so the three
+            // settlement detectors (WebSocket / LUD-21 verify / GraphQL poll) can't
+            // double-fire if more than one observes the same payment.
+            if (!this.successFired) {
+                this.successFired = true;
+                const donation = this.lastDonation || {};
+                this.fireCallback('onSuccess', {
+                    username: this.username,
+                    amount: donation.amount,
+                    currency: donation.currency,
+                    paymentRequest: this.currentPaymentRequest
+                });
+            }
         },
         
         // Set the loading state of the button
@@ -2695,7 +2751,7 @@
             }
             
             // Add widget version for tracking
-            params.append('widget_version', '1.3.3');
+            params.append('widget_version', '1.4.0');
             
             return `${baseUrl}?${params.toString()}`;
         }

--- a/js/blink-pay-button.js
+++ b/js/blink-pay-button.js
@@ -4,7 +4,9 @@
  * Version: 1.4.0 - Optional embedder lifecycle callbacks (onSuccess/onError/
  *                  onTimeout). Additive only; existing public API unchanged.
  *                  Callbacks are invoked via a try/catch-wrapped fireCallback so a
- *                  throwing embedder handler can never break the widget.
+ *                  throwing embedder handler can never break the widget. onError
+ *                  also covers exchange-rate lookup failures (not just invoice/
+ *                  processing errors); input-validation errors stay UI-only.
  *          1.3.3 - Make payment-poll cancellation race-safe: a generation token
  *                  ensures a poll loop cannot resume after stop/reset when its
  *                  request was already in flight (would otherwise poll unbounded).
@@ -1424,7 +1426,11 @@
                             await this.fetchExchangeRate(this.selectedCurrency);
                             exchangeRates = this.exchangeRates[this.selectedCurrency];
                         } catch (error) {
-                            return; // Error already shown in fetchExchangeRate
+                            // Error UI already shown in fetchExchangeRate. This is a
+                            // failed donation attempt (not input validation), so notify
+                            // the embedder before bailing out.
+                            this.fireCallback('onError', { error, message: error.message });
+                            return;
                         }
                     }
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blink-donation-button",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Blink Pay Button donation widget — tests for custodial + self-custodial (Spark) receive.",
   "private": true,
   "type": "module",

--- a/tests/widget-callbacks.spec.js
+++ b/tests/widget-callbacks.spec.js
@@ -200,4 +200,40 @@ describe('onError', () => {
         expect(arg.message).toBe('wallet lookup failed');
         expect(arg.error).toBe(boom);
     });
+
+    it('fires when the exchange-rate lookup fails for a fiat currency', async () => {
+        const onError = vi.fn();
+        initWidget({ onError });
+
+        // Fiat display currency with no cached rate forces a fetchExchangeRate call
+        // in handleDonate before any wallet lookup; make it reject.
+        const rateError = new Error('rate fetch failed');
+        widget.selectedCurrency = 'EUR';
+        widget.exchangeRates = {};
+        widget.fetchExchangeRate = vi.fn(() => Promise.reject(rateError));
+
+        document.getElementById('blink-pay-amount').value = '5';
+
+        await widget.handleDonate();
+
+        expect(widget.fetchExchangeRate).toHaveBeenCalledWith('EUR');
+        expect(onError).toHaveBeenCalledTimes(1);
+        const arg = onError.mock.calls[0][0];
+        expect(arg.message).toBe('rate fetch failed');
+        expect(arg.error).toBe(rateError);
+    });
+
+    it('does NOT fire on input-validation failures (UI-only)', async () => {
+        const onError = vi.fn();
+        initWidget({ onError });
+
+        // amount <= 0 is rejected by validation, which shows a UI error and returns
+        // early WITHOUT firing onError (documented boundary).
+        widget.selectedCurrency = 'sats';
+        document.getElementById('blink-pay-amount').value = '0';
+
+        await widget.handleDonate();
+
+        expect(onError).not.toHaveBeenCalled();
+    });
 });

--- a/tests/widget-callbacks.spec.js
+++ b/tests/widget-callbacks.spec.js
@@ -1,0 +1,203 @@
+/**
+ * Tests for the optional embedder lifecycle callbacks in js/blink-pay-button.js
+ * (onSuccess / onError / onTimeout), added in 1.4.0.
+ *
+ * Contract guarded here:
+ *  - Callbacks are only registered when they are functions (bad values ignored).
+ *  - onSuccess fires once per settled invoice with a rich payload
+ *    ({ username, amount, currency, paymentRequest }) and is double-fire safe
+ *    across the three settlement detectors.
+ *  - onError fires when a donation attempt fails.
+ *  - onTimeout fires once when the invoice countdown reaches 0:00.
+ *  - A throwing embedder handler is swallowed (never breaks the widget).
+ *  - Omitting the callbacks is null-safe.
+ *
+ * The widget is loaded by executing its IIFE source (the same approach the other
+ * specs use) so we exercise the real shipped file.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const widgetSrc = readFileSync(resolve(__dirname, '../js/blink-pay-button.js'), 'utf8');
+
+function loadWidget() {
+    const run = new Function(widgetSrc);
+    run();
+    return window.BlinkPayButton;
+}
+
+let widget;
+
+beforeEach(() => {
+    // jsdom has no ResizeObserver; the widget guards on it but stub anyway.
+    global.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    };
+    window.ResizeObserver = global.ResizeObserver;
+
+    document.body.innerHTML = '<div id="blink-pay-button-container"></div>';
+    widget = loadWidget();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+    delete global.ResizeObserver;
+    delete window.ResizeObserver;
+});
+
+function initWidget(extra = {}) {
+    widget.init({
+        username: 'alice',
+        containerId: 'blink-pay-button-container',
+        debug: false,
+        ...extra,
+    });
+    widget.log = () => {};
+}
+
+describe('callback registration', () => {
+    it('registers function callbacks', () => {
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+        const onTimeout = vi.fn();
+        initWidget({ onSuccess, onError, onTimeout });
+
+        expect(widget.onSuccess).toBe(onSuccess);
+        expect(widget.onError).toBe(onError);
+        expect(widget.onTimeout).toBe(onTimeout);
+    });
+
+    it('ignores non-function callback values', () => {
+        initWidget({ onSuccess: 'nope', onError: 42, onTimeout: {} });
+
+        expect(widget.onSuccess).toBeNull();
+        expect(widget.onError).toBeNull();
+        expect(widget.onTimeout).toBeNull();
+    });
+
+    it('defaults to null when omitted', () => {
+        initWidget();
+        expect(widget.onSuccess).toBeNull();
+        expect(widget.onError).toBeNull();
+        expect(widget.onTimeout).toBeNull();
+    });
+});
+
+describe('fireCallback', () => {
+    it('passes the payload through to the handler', () => {
+        const onSuccess = vi.fn();
+        initWidget({ onSuccess });
+        widget.fireCallback('onSuccess', { foo: 'bar' });
+        expect(onSuccess).toHaveBeenCalledWith({ foo: 'bar' });
+    });
+
+    it('swallows errors thrown by the embedder handler', () => {
+        const onError = vi.fn(() => {
+            throw new Error('embedder blew up');
+        });
+        initWidget({ onError });
+        // Must not throw out of fireCallback.
+        expect(() => widget.fireCallback('onError', {})).not.toThrow();
+        expect(onError).toHaveBeenCalled();
+    });
+
+    it('is a no-op when no handler is registered', () => {
+        initWidget();
+        expect(() => widget.fireCallback('onSuccess', {})).not.toThrow();
+    });
+});
+
+describe('onSuccess', () => {
+    it('fires once with the rich payload on payment success', () => {
+        const onSuccess = vi.fn();
+        initWidget({ onSuccess });
+
+        // Simulate the state stashed during a donation + invoice display.
+        widget.lastDonation = { amount: 1000, currency: 'sats' };
+        widget.currentPaymentRequest = 'lnbc1test';
+        widget.successFired = false;
+
+        widget.handlePaymentSuccess();
+
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(onSuccess).toHaveBeenCalledWith({
+            username: 'alice',
+            amount: 1000,
+            currency: 'sats',
+            paymentRequest: 'lnbc1test',
+        });
+    });
+
+    it('does not double-fire if handlePaymentSuccess runs twice', () => {
+        const onSuccess = vi.fn();
+        initWidget({ onSuccess });
+        widget.lastDonation = { amount: 5, currency: 'USD' };
+        widget.currentPaymentRequest = 'lnbc1twice';
+        widget.successFired = false;
+
+        widget.handlePaymentSuccess();
+        widget.handlePaymentSuccess();
+
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it('still completes the success UI when no callback is set', () => {
+        initWidget();
+        widget.currentPaymentRequest = 'lnbc1nocb';
+        widget.successFired = false;
+        expect(() => widget.handlePaymentSuccess()).not.toThrow();
+        const success = document.getElementById('blink-pay-success');
+        expect(success.classList.contains('blink-pay-show')).toBe(true);
+    });
+});
+
+describe('onTimeout', () => {
+    it('fires once when displayInvoice countdown reaches zero', () => {
+        vi.useFakeTimers();
+        try {
+            const onTimeout = vi.fn();
+            initWidget({ onTimeout });
+
+            // 0-minute expiry: the first countdown tick is already <= 0.
+            widget.displayInvoice('lnbc1expire', 0);
+
+            // Advance enough to run the initial tick + a couple of intervals.
+            vi.advanceTimersByTime(3000);
+
+            expect(onTimeout).toHaveBeenCalledTimes(1);
+            expect(onTimeout).toHaveBeenCalledWith({ paymentRequest: 'lnbc1expire' });
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});
+
+describe('onError', () => {
+    it('fires when a donation attempt throws', async () => {
+        const onError = vi.fn();
+        initWidget({ onError });
+
+        // Force an early failure inside handleDonate's try block.
+        const boom = new Error('wallet lookup failed');
+        widget.getAccountDefaultWallet = vi.fn(() => {
+            throw boom;
+        });
+
+        // Provide a valid sats amount so we reach the processing try/catch.
+        document.getElementById('blink-pay-amount').value = '1000';
+        widget.selectedCurrency = 'sats';
+
+        await widget.handleDonate();
+
+        expect(onError).toHaveBeenCalledTimes(1);
+        const arg = onError.mock.calls[0][0];
+        expect(arg.message).toBe('wallet lookup failed');
+        expect(arg.error).toBe(boom);
+    });
+});


### PR DESCRIPTION
## Summary

Tier 2 (PR 1 of 2). Adds **optional** embedder lifecycle callbacks so sites embedding the widget can react to donation events (analytics, thank-you UI, error monitoring). Additive only — the public API is **extended, never changed**.

## Callbacks

| Option | Payload | Fires when |
|---|---|---|
| `onSuccess` | `{ username, amount, currency, paymentRequest }` | a donation is paid |
| `onError` | `{ error, message }` | a donation attempt fails |
| `onTimeout` | `{ paymentRequest }` | the displayed invoice expires unpaid |

## Design notes

- **Single success hook**: `onSuccess` fires from `handlePaymentSuccess()`, the one convergence point for all three settlement detectors (custodial WebSocket, Spark LUD-21 verify, GraphQL poll), so it can't miss or double-fire. Guarded with a per-invoice `successFired` flag.
- **Crash-safe**: all callbacks run through a try/catch-wrapped `fireCallback()` — a throwing embedder handler is logged (debug-gated) and never breaks the widget flow.
- **Defensive config**: non-function values are ignored; omitting callbacks is a no-op.
- **Payload plumbing**: `amount`/`currency` are stashed on donate (`lastDonation`) and `paymentRequest` on `displayInvoice`, since neither is otherwise in scope at settlement time. `onTimeout` is fired once per invoice via a `timeoutFired` guard.

## Guardrails (per AGENTS.md)

- No change to existing public API (container-id contract, existing options, success/QR DOM behavior).
- Single-file embed unaffected; no new required `<script>` tags.
- Version bumped to **1.4.0**: widget header, `package.json`, and analytics `widget_version`.

## Testing

- `npm test`: **72/72 pass** (was 61; +11 new in `tests/widget-callbacks.spec.js` covering registration, payloads, double-fire safety, throwing-handler isolation, and null-safety).
- Manual smoke: `analytics-test.html` now wires all three callbacks to an on-page log + console.

## Out of scope

PR 2 (inline client-side QR to drop `api.qrserver.com`) — separate follow-up; library choice to be decided in its planning.