### PR TITLE
copy: rename "Donation Button" to "Donate Button" across UI and docs

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Blink Donation Button Generator</title>
+    <title>Blink Donate Button Generator</title>
     <meta name="robots" content="noindex">
     <!--
         GitHub Pages has no server-side routing: it serves static files by exact
@@ -16,7 +16,7 @@
 
         This page captures the requested path, stashes the candidate username in
         sessionStorage, and redirects to "/", where js/generator.js reads it and
-        auto-generates that user's donation button. If the path isn't a plausible
+        auto-generates that user's donate button. If the path isn't a plausible
         single-segment username, we just send the visitor to the generator home.
 
         Kept dependency-free and inline so it runs before any render.
@@ -83,7 +83,7 @@
     <noscript>
         <p>
             Page not found. Visit the
-            <a href="/">Blink Donation Button Generator</a>.
+            <a href="/">Blink Donate Button Generator</a>.
         </p>
     </noscript>
 </body>

--- a/ANALYTICS-README.md
+++ b/ANALYTICS-README.md
@@ -1,8 +1,8 @@
-# Blink Donation Button - Analytics Tracking
+# Blink Donate Button - Analytics Tracking
 
 ## Overview
 
-The Blink Donation Button widget now includes built-in analytics tracking to help the Blink team understand how and where their widget is being used, and to track referrals from embedded donation buttons.
+The Blink Donate Button widget now includes built-in analytics tracking to help the Blink team understand how and where their widget is being used, and to track referrals from embedded donate buttons.
 
 ## How It Works
 
@@ -27,7 +27,7 @@ https://get.blink.sv?username=twentyone&referral=embedded_donation_button&embed_
 
 This analytics tracking enables Blink to:
 
-1. **Track Widget Usage**: See how many people are using embedded donation buttons
+1. **Track Widget Usage**: See how many people are using embedded donate buttons
 2. **Identify Popular Sites**: Understand which websites are driving the most referrals
 3. **User Acquisition**: Track new users coming from embedded widgets
 4. **Feature Analytics**: Monitor widget version adoption and usage patterns

--- a/MULTILANG-README.md
+++ b/MULTILANG-README.md
@@ -1,6 +1,6 @@
-# Multi-Language Support for Blink Donation Button
+# Multi-Language Support for Blink Donate Button
 
-The Blink Donation Button widget now supports **35+ languages**, making Bitcoin Lightning donations accessible to users worldwide, with particular focus on Global South countries.
+The Blink Donate Button widget now supports **35+ languages**, making Bitcoin Lightning donations accessible to users worldwide, with particular focus on Global South countries.
 
 ## Supported Languages
 
@@ -64,7 +64,7 @@ This language expansion specifically targets Global South regions where Bitcoin 
 
 ### Using the Generator
 
-When using the [Blink Donation Button Generator](https://blinkbitcoin.github.io/donation-button.blink.sv/), you can now:
+When using the [Blink Donate Button Generator](https://blinkbitcoin.github.io/donation-button.blink.sv/), you can now:
 
 1. Select your preferred language from the "Widget Language" dropdown
 2. The generator will include the language parameter in the generated code

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Blink Donation Button Widget
+# Blink Donate Button Widget
 
 A lightweight, embeddable Bitcoin Lightning donation widget that integrates with [Blink](https://blink.sv/) for instant, low-fee Bitcoin payments. Built with vanilla JavaScript and designed for easy integration into any website.
 
@@ -20,7 +20,7 @@ A lightweight, embeddable Bitcoin Lightning donation widget that integrates with
 
 **Generator**: [https://blinkbitcoin.github.io/donation-button.blink.sv/](https://blinkbitcoin.github.io/donation-button.blink.sv/)
 
-Try the widget generator to create your own donation button in seconds!
+Try the widget generator to create your own donate button in seconds!
 
 ## 🏃‍♂️ Quick Start
 
@@ -37,10 +37,10 @@ Visit [blinkbitcoin.github.io/donation-button.blink.sv](https://blinkbitcoin.git
 Paste the generated code into your HTML:
 
 ```html
-<!-- Blink Donation Button widget -->
+<!-- Blink Donate Button widget -->
 <div id="blink-pay-button-container"></div>
 
-<!-- Blink Donation Button script -->
+<!-- Blink Donate Button script -->
 <script src="https://blinkbitcoin.github.io/donation-button.blink.sv/js/blink-pay-button.js"></script>
 <script>
   BlinkPayButton.init({
@@ -162,7 +162,7 @@ self-custodial (Spark) username.
 
 ## 📊 Analytics Tracking
 
-The widget includes built-in analytics tracking when users click the Blink logo. This helps Blink understand widget usage and track referrals from embedded donation buttons.
+The widget includes built-in analytics tracking when users click the Blink logo. This helps Blink understand widget usage and track referrals from embedded donate buttons.
 
 **Tracked Information:**
 - Username configured in the widget
@@ -174,7 +174,7 @@ The widget includes built-in analytics tracking when users click the Blink logo.
 
 ## 🎨 Styling & Responsive Design
 
-The widget automatically adapts to light/dark themes and is fully responsive. The donation button is designed to work seamlessly in various container sizes and environments, including Elementor containers.
+The widget automatically adapts to light/dark themes and is fully responsive. The donate button is designed to work seamlessly in various container sizes and environments, including Elementor containers.
 
 ### Responsive Features
 

--- a/analytics-test.html
+++ b/analytics-test.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Analytics URL Test - Blink Donation Button</title>
+    <title>Analytics URL Test - Blink Donate Button</title>
     <style>
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
@@ -69,7 +69,7 @@
     <div class="container">
         <h1>🔗 Analytics URL Test</h1>
         
-        <p>This page demonstrates the analytics tracking feature of the Blink Donation Button widget. When users click the Blink logo in the widget, they are redirected to Blink's signup page with analytics parameters.</p>
+        <p>This page demonstrates the analytics tracking feature of the Blink Donate Button widget. When users click the Blink logo in the widget, they are redirected to Blink's signup page with analytics parameters.</p>
 
         <div class="analytics-demo">
             <h3>📊 Generated Analytics URL</h3>

--- a/index.html
+++ b/index.html
@@ -3,28 +3,28 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Blink Donation Button Generator</title>
+    <title>Blink Donate Button Generator</title>
     
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Create a Bitcoin Lightning donation button for your website. Easy-to-embed widget that accepts instant Bitcoin payments via Blink wallet with support for 35+ languages and 30+ currencies.">
+    <meta name="description" content="Create a Bitcoin Lightning donate button for your website. Easy-to-embed widget that accepts instant Bitcoin payments via Blink wallet with support for 35+ languages and 30+ currencies.">
     <meta name="keywords" content="bitcoin, lightning, donation, button, widget, blink, crypto, payments, generator">
     <meta name="author" content="Blink">
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://donation-button.blink.sv/">
-    <meta property="og:title" content="Blink Donation Button Generator - Create bitcoin donation buttons">
-    <meta property="og:description" content="Create a Bitcoin Lightning donation button for your website. Easy-to-embed widget that accepts instant Bitcoin payments via Blink wallet with support for 35+ languages and 30+ currencies.">
+    <meta property="og:title" content="Blink Donate Button Generator - Create bitcoin donate buttons">
+    <meta property="og:description" content="Create a Bitcoin Lightning donate button for your website. Easy-to-embed widget that accepts instant Bitcoin payments via Blink wallet with support for 35+ languages and 30+ currencies.">
     <meta property="og:image" content="https://donation-button.blink.sv/img/meta-standard-1200x630.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:site_name" content="Blink Donation Button Generator">
+    <meta property="og:site_name" content="Blink Donate Button Generator">
     
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://donation-button.blink.sv/">
-    <meta property="twitter:title" content="Blink Donation Button Generator - Create bitcoin donation buttons">
-    <meta property="twitter:description" content="Create a Bitcoin Lightning donation button for your website. Easy-to-embed widget that accepts instant Bitcoin payments via Blink wallet with support for 35+ languages and 30+ currencies.">
+    <meta property="twitter:title" content="Blink Donate Button Generator - Create bitcoin donate buttons">
+    <meta property="twitter:description" content="Create a Bitcoin Lightning donate button for your website. Easy-to-embed widget that accepts instant Bitcoin payments via Blink wallet with support for 35+ languages and 30+ currencies.">
     <meta property="twitter:image" content="https://donation-button.blink.sv/img/meta-twitter-1200x628.png">
     <meta property="twitter:site" content="@blinkbtc">
     <meta property="twitter:creator" content="@blinkbtc">
@@ -335,13 +335,13 @@
             <div class="col-md-10 col-lg-8">
                 <div class="text-center mb-4">
                     <img src="img/blink-light.svg" alt="Blink Logo" class="logo" id="header-logo">
-                    <h1 class="page-title">Blink Donation Button Generator</h1>
-                    <p class="lead">Create a Bitcoin Lightning donation button for your website</p>
+                    <h1 class="page-title">Blink Donate Button Generator</h1>
+                    <p class="lead">Create a Bitcoin Lightning donate button for your website</p>
                 </div>
                 
                 <div class="card mb-4">
                     <div class="card-body">
-                        <h2 class="card-title">Generate Your Donation Button</h2>
+                        <h2 class="card-title">Generate Your Donate Button</h2>
                         <div class="mb-3">
                             <label for="blinkUsername" class="form-label">Your Blink Username</label>
                             <div class="input-group">
@@ -432,7 +432,7 @@
                     
                     <div class="card mb-4">
                         <div class="card-body">
-                            <h2 class="card-title">Your Donation Button Code</h2>
+                            <h2 class="card-title">Your Donate Button Code</h2>
                             <p>Copy and paste this code into your website HTML:</p>
                             
                             <div class="code-container">

--- a/js/blink-pay-button.js
+++ b/js/blink-pay-button.js
@@ -1,7 +1,17 @@
 /**
  * Blink Pay Button Widget
  * A simple widget for accepting Bitcoin Lightning donations via Blink wallet
- * Version: 1.5.1 - Stop LUD-21 verify polling early ONLY on a stable terminal
+ * Version: 1.5.2 - Copy: the widget is now the "Donate Button" (was "Donation Button")
+ *                  across the generator UI, docs and manual test pages. The invoice memo
+ *                  sent on both receive paths changes from "<username> donation button"
+ *                  to "<username> donate button". On the custodial path that memo is the
+ *                  invoice description payers see; on the self-custodial (Spark) path it
+ *                  is sent as the LUD-12 comment, so the payer-visible description stays
+ *                  the LNURL metadata ("Payment to <username>") as before. Analytics
+ *                  referral tag ('embedded_donation_button') and all
+ *                  donation-button.blink.sv paths are deliberately unchanged.
+ *                  No public API / DOM changes.
+ *          1.5.1 - Stop LUD-21 verify polling early ONLY on a stable terminal
  *                  verify error (status:ERROR with a "not found" reason: the
  *                  invoice will never settle) instead of re-polling until expiry.
  *                  Ambiguous/transient ERRORs — "Internal server error", a
@@ -1673,7 +1683,7 @@
             const satsAmount = this.convertToSatoshis(amount, this.selectedCurrency);
             this.log('Self-custodial: requesting LN-address invoice', { lightningAddress, satsAmount });
 
-            const memo = `${this.username} donation button`;
+            const memo = `${this.username} donate button`;
             let invoice;
             try {
                 invoice = await lnurl.getInvoiceFromLightningAddress(
@@ -1875,7 +1885,7 @@
                 input: {
                     recipientWalletId: walletId,
                     amount: amount.toString(),
-                    memo: `${this.username} donation button`,
+                    memo: `${this.username} donate button`,
                     expiresIn: "15"
                 }
             };
@@ -1899,7 +1909,7 @@
                     input: {
                         amount: amount.toString(),
                         recipientWalletId: walletId,
-                        memo: `${this.username} donation button`,
+                        memo: `${this.username} donate button`,
                         expiresIn: "5"
                     }
                 };
@@ -2767,7 +2777,7 @@
             }
             
             // Add widget version for tracking
-            params.append('widget_version', '1.5.1');
+            params.append('widget_version', '1.5.2');
             
             return `${baseUrl}?${params.toString()}`;
         }

--- a/js/generator.js
+++ b/js/generator.js
@@ -1,6 +1,6 @@
 /**
- * Blink Donation Button Generator
- * Generates embeddable code for a Bitcoin Lightning donation button
+ * Blink Donate Button Generator
+ * Generates embeddable code for a Bitcoin Lightning donate button
  */
 
 /**
@@ -8,7 +8,7 @@
  *
  * The generator supports a username-customized URL so external surfaces (e.g.
  * the Blink mobile app "Ways to get paid" section) can link straight to a
- * pre-generated donation button, e.g.:
+ * pre-generated donate button, e.g.:
  *
  *     https://donation-button.blink.sv/pretyflaco
  *
@@ -534,10 +534,10 @@ function initGenerator() {
         const buttonWidthConfig = currentButtonWidth ? `\n        buttonWidth: ${currentButtonWidth},` : '';
         
         // Generate the HTML code for embedding with the domain
-        const generatedCode = `<!-- Blink Donation Button widget -->
+        const generatedCode = `<!-- Blink Donate Button widget -->
 <div id="blink-pay-button-container"></div>
 
-<!-- Blink Donation Button script -->
+<!-- Blink Donate Button script -->
         <script src="https://blinkbitcoin.github.io/donation-button.blink.sv/js/blink-pay-button.js"></script>
 <script>
   // Initialize widget when script is loaded
@@ -727,7 +727,7 @@ function initGenerator() {
     // Deep-link bootstrap: if the page was reached via a username-customized URL
     // (e.g. https://donation-button.blink.sv/pretyflaco, linked from the Blink
     // app's "Ways to get paid" section), prefill the username and auto-generate
-    // so the visitor lands straight on their donation button. Existence is still
+    // so the visitor lands straight on their donate button. Existence is still
     // verified inside generateCode() (with the Spark LNURL fallback), so an
     // unknown username shows the normal "does not exist yet" message.
     const deepLinkUsername = resolveDeepLinkUsername(window);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blink-donation-button",
   "version": "1.5.0",
-  "description": "Blink Donation Button widget — tests for custodial + self-custodial (Spark) receive.",
+  "description": "Blink Donate Button widget — tests for custodial + self-custodial (Spark) receive.",
   "private": true,
   "type": "module",
   "scripts": {

--- a/responsive-test.html
+++ b/responsive-test.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Blink Donation Button - Responsive Test</title>
+    <title>Blink Donate Button - Responsive Test</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -99,8 +99,8 @@
 </head>
 <body>
     <div class="container">
-        <h1>Blink Donation Button - Responsive Test</h1>
-        <p>This page demonstrates the responsive behavior of the Blink donation button in different container sizes and scenarios.</p>
+        <h1>Blink Donate Button - Responsive Test</h1>
+        <p>This page demonstrates the responsive behavior of the Blink donate button in different container sizes and scenarios.</p>
         
         <div class="test-section">
             <h2>1. Default Responsive Button</h2>
@@ -196,7 +196,7 @@
         </div>
     </div>
 
-    <!-- Blink Donation Button script -->
+    <!-- Blink Donate Button script -->
     <script src="js/blink-pay-button.js"></script>
     <script>
         // Initialize multiple widgets with different configurations

--- a/spark-test.html
+++ b/spark-test.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Blink Donation Button — Self-custodial (Spark) test</title>
+    <title>Blink Donate Button — Self-custodial (Spark) test</title>
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -46,7 +46,7 @@
     </style>
 </head>
 <body>
-    <h1>Self-custodial (Spark) donation button — manual test</h1>
+    <h1>Self-custodial (Spark) donate button — manual test</h1>
 
     <div class="note">
         This page exercises the <strong>self-custodial (Spark) receive path</strong>.

--- a/test-multilang.html
+++ b/test-multilang.html
@@ -47,7 +47,7 @@
 </head>
 <body>
     <div class="test-container">
-        <h1>Blink Donation Button - Multi-Language Test</h1>
+        <h1>Blink Donate Button - Multi-Language Test</h1>
         
         <div class="language-buttons">
             <button onclick="changeLanguage('en')" class="active" id="btn-en">English</button>

--- a/tests/blink-lnurl.spec.js
+++ b/tests/blink-lnurl.spec.js
@@ -175,7 +175,7 @@ describe('blink-lnurl helpers', () => {
       const result = await BlinkLnurl.getInvoiceFromLightningAddress(
         'yasar@blink.sv',
         5000,
-        'yasar donation button',
+        'yasar donate button',
         fetchMock
       );
       expect(result.paymentRequest).toBe('lnbc1sparkinvoice');

--- a/tests/generator-deeplink.spec.js
+++ b/tests/generator-deeplink.spec.js
@@ -4,7 +4,7 @@
  * The generator supports username-customized URLs (e.g.
  * https://donation-button.blink.sv/pretyflaco) so external surfaces like the
  * Blink app's "Ways to get paid" section can link straight to a pre-generated
- * donation button. 404.html captures the path and hands the username to the
+ * donate button. 404.html captures the path and hands the username to the
  * generator via sessionStorage; these helpers turn a raw path into a candidate
  * username and resolve the deep-link username for a page load.
  *

--- a/tests/widget-spark.spec.js
+++ b/tests/widget-spark.spec.js
@@ -99,7 +99,7 @@ describe('widget inline Spark helpers (getLnurl)', () => {
     const result = await inline.getInvoiceFromLightningAddress(
       'yasar@blink.sv',
       5000,
-      'yasar donation button'
+      'yasar donate button'
     );
     expect(result.paymentRequest).toBe('lnbc1sparkinvoice');
     expect(result.verifyUrl).toBe('https://blink.sv/verify/abc');

--- a/wordpress-test-snippet.html
+++ b/wordpress-test-snippet.html
@@ -47,17 +47,17 @@
 &lt;div style="width: 220px; border: 2px solid #007cba; padding: 15px; margin: 20px auto; background: #f8f9fa; border-radius: 8px;"&gt;
     &lt;div style="text-align: center; font-weight: bold; color: #007cba; margin-bottom: 10px; font-size: 12px;"&gt;WordPress Test Container (220px)&lt;/div&gt;
     
-    &lt;!-- Blink Donation Button Container --&gt;
+    &lt;!-- Blink Donate Button Container --&gt;
     &lt;div id="blink-pay-button-container"&gt;&lt;/div&gt;
     
     &lt;!-- Debug Info --&gt;
     &lt;div id="debug-info" style="background: #e9ecef; padding: 8px; margin-top: 10px; font-family: monospace; font-size: 11px; border-radius: 4px; border: 1px solid #dee2e6;"&gt;Loading...&lt;/div&gt;
 &lt;/div&gt;
 
-&lt;!-- Blink Donation Button Script --&gt;
+&lt;!-- Blink Donate Button Script --&gt;
 &lt;script src="https://donation-button.blink.sv/js/blink-pay-button.js"&gt;&lt;/script&gt;
 &lt;script&gt;
-    // Initialize the donation button
+    // Initialize the donate button
     BlinkPayButton.init({
         username: 'pretyflaco',
         containerId: 'blink-pay-button-container',
@@ -94,7 +94,7 @@
 
     <script src="js/blink-pay-button.js"></script>
     <script>
-        // Initialize the donation button
+        // Initialize the donate button
         BlinkPayButton.init({
             username: 'pretyflaco',
             containerId: 'blink-pay-button-container',


### PR DESCRIPTION
The widget is called the **Donate Button** in product copy, but the repo said
"Donation Button" throughout. This renames the user-facing string everywhere it
appears, and stops at identifiers.

`ab23734` (#9) made "Donation Button" consistent; this is the same sweep in the
other direction, now that the name has settled.

## What changed

**Commit 1 — copy across UI and docs** (13 files, no behavior change)

- `index.html` / `404.html`: `<title>`, page and card headings, lead copy, and the
  `og:`/`twitter:` meta tags.
- `js/generator.js`: the embed-snippet comments the generator emits
  (`<!-- Blink Donate Button widget/script -->`), kept in sync with the copy of that
  same snippet in `README.md`.
- `README` / `MULTILANG-README` / `ANALYTICS-README`, the `package.json` description,
  and the `*-test.html` pages.

**Commit 2 — invoice memo + version bump** (payment-path; isolated for review)

The memo was the last payer-visible "donation button" string. The two receive paths
differ, and only one is actually affected:

- **Custodial:** the memo is the invoice description the payer's wallet renders
  (`lnInvoiceCreateOnBehalfOfRecipient` and the USD variant), so payers now see
  `<username> donate button`.
- **Self-custodial (Spark):** the memo is sent as the LUD-12 `comment`, while the
  description comes from the LNURL metadata server-side (`Payment to <username>`).
  That path's payer-visible text is unchanged by this PR, as it was before it.
  blink.sv advertises `commentAllowed: 255`, well above the memo length, so nothing
  is truncated.

Version `1.5.1 -> 1.5.2` plus the analytics `widget_version`, per AGENTS.md.

## Deliberately NOT renamed

Renaming these would break live embeds or split analytics history:

| Identifier | Why it stays |
| --- | --- |
| `donation-button.blink.sv` (Pages path, all URLs) | every embed in the wild loads its script from this path |
| `blink-donation-button` (`package.json` name) | package identity |
| `embedded_donation_button` (analytics `referral` tag) | renaming splits the metric's history |

## Acceptance requirements

- [x] Every user-facing "Donation Button" / "donation button" reads "Donate Button" /
      "donate button" — zero occurrences remain repo-wide.
- [x] The Pages path, package name and analytics referral tag are unchanged.
- [x] The embed snippet in `README.md` still matches the one `js/generator.js` emits.
- [x] No public API change: `BlinkPayButton.init`, its config options, the container-id
      contract and the success/QR DOM behavior are untouched.
- [x] Widget version header and analytics `widget_version` bumped together.
- [ ] Custodial smoke: a real small donation shows `<username> donate button` as the
      invoice description in the payer's wallet.

## Testing specs

Automated — **147 tests pass across 11 files**, eslint clean (4 pre-existing
`no-unused-vars` warnings, untouched):

```bash
npm ci && npm test && npm run lint
```

The two memo assertions move with the change:
- `tests/blink-lnurl.spec.js` — canonical `getInvoiceFromLightningAddress`
- `tests/widget-spark.spec.js` — the inline-copy parity test

Manual — per AGENTS.md, payment-path changes want a real smoke:
- `spark-test.html` against a self-custodial username. Expect the description to read
  `Payment to <username>` (LNURL metadata, unchanged by this PR) — the memo rides
  along as the LUD-12 comment.
- A custodial username is the case that actually changes; expect
  `<username> donate button` in the payer's wallet. **Not yet run — needs a
  maintainer with a custodial test account.**

Not addressed here: `npm run format` currently fails on 11 files on `main` (including
files this PR never touches). CI runs `npm ci && npm test`, so it is green. Reformatting
belongs in its own PR.

## Screenshots

<img alt="image" src="https://github.com/user-attachments/assets/19954a42-d4f5-41ff-a6d3-ad59263d3680" />
